### PR TITLE
feat: adds price bounds fetch, changing filter #50

### DIFF
--- a/src/components/pages/rns/buy/DomainOffersPage.tsx
+++ b/src/components/pages/rns/buy/DomainOffersPage.tsx
@@ -1,3 +1,4 @@
+import { Web3Store } from '@rsksmart/rif-ui';
 import { createOffersService, DOMAINS_SERVICE_PATHS, fetchDomainOffers } from 'api/rif-marketplace-cache/domainsController';
 import CombinedPriceCell from 'components/molecules/CombinedPriceCell';
 import SelectRowButton from 'components/molecules/table/SelectRowButton';
@@ -9,7 +10,6 @@ import { useHistory } from 'react-router';
 import { ROUTES } from 'routes';
 import { MARKET_ACTIONS } from 'store/Market/marketActions';
 import MarketStore, { TxType } from 'store/Market/MarketStore';
-import { Web3Store } from '@rsksmart/rif-ui';
 
 const LISTING_TYPE = MarketListingTypes.DOMAIN_OFFERS;
 const TX_TYPE = TxType.BUY;

--- a/src/models/Market.ts
+++ b/src/models/Market.ts
@@ -18,7 +18,7 @@ export type MarketItemType = Domain & DomainOffer & StorageItemIface
 export interface MarketFilter {
     [filterFieldName: string]: {
         [filterType: string]: any
-    } | undefined
+    } | any | undefined
 }
 
 export type MarketFilterType = DomainFilter & DomainOffersFilter


### PR DESCRIPTION
Closes #50 
Adds a request to the cache to get the min and max price. Calling it from componentWillMount of the DomainOfferFilters, it sets edge values of the RangeFilter component.
As mentioned in the issue this closes, a [rif-ui issue](https://github.com/rsksmart/rif-ui/issues/10) prevents us from changing the inputs associated with the bounds of the range slider programmatically.
The result is that, though the slider itself updates its values, as well as does the marketplace (showing items according to min max boundaries), the <input> parts of the slider are not representing this change.
As soon as this is fixed in the rif-ui, the behaviour should be as expected.