### PR TITLE
hotfixes - styles and pop up login modal before navigating to sell domains

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2202,8 +2202,8 @@
       }
     },
     "@rsksmart/rif-ui": {
-      "version": "github:rsksmart/rif-ui#28e46eedbbebc1f10f2fd4490a4cc8d1b685c843",
-      "from": "github:rsksmart/rif-ui"
+      "version": "github:rsksmart/rif-ui#c315b21ab41c8a5601e42a2a30f79fdbebe3ee73",
+      "from": "github:rsksmart/rif-ui#hotfix/accountStyling"
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2202,8 +2202,8 @@
       }
     },
     "@rsksmart/rif-ui": {
-      "version": "github:rsksmart/rif-ui#c315b21ab41c8a5601e42a2a30f79fdbebe3ee73",
-      "from": "github:rsksmart/rif-ui#hotfix/accountStyling"
+      "version": "github:rsksmart/rif-ui#160edc8b8a3092126594101f615b70d373fb37d1",
+      "from": "github:rsksmart/rif-ui"
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2202,7 +2202,7 @@
       }
     },
     "@rsksmart/rif-ui": {
-      "version": "github:rsksmart/rif-ui#160edc8b8a3092126594101f615b70d373fb37d1",
+      "version": "github:rsksmart/rif-ui#e08fe5f054badbf4b07de6e4ec8332579d3234f5",
       "from": "github:rsksmart/rif-ui"
     },
     "@samverschueren/stream-to-observable": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@rsksmart/erc677": "^1.0.2",
     "@rsksmart/erc721": "^1.0.0",
     "@rsksmart/rif-marketplace-nfts": "0.0.2",
-    "@rsksmart/rif-ui": "github:rsksmart/rif-ui#hotfix/accountStyling",
+    "@rsksmart/rif-ui": "github:rsksmart/rif-ui",
     "@truffle/contract": "^4.2.1",
     "@truffle/debug-utils": "^4.1.1",
     "formik": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "decentralized",
     "RSK"
   ],
-  "homepage": "https://github.com/rsksmart/rif-marketplace-ui",
+  "homepage": ".",
   "bugs": {
     "url": "https://github.com/rsksmart/rif-marketplace-ui/issues/"
   },
@@ -37,7 +37,7 @@
     "@rsksmart/erc677": "^1.0.2",
     "@rsksmart/erc721": "^1.0.0",
     "@rsksmart/rif-marketplace-nfts": "0.0.2",
-    "@rsksmart/rif-ui": "github:rsksmart/rif-ui",
+    "@rsksmart/rif-ui": "github:rsksmart/rif-ui#hotfix/accountStyling",
     "@truffle/contract": "^4.2.1",
     "@truffle/debug-utils": "^4.1.1",
     "formik": "^2.1.4",

--- a/src/components/Routes.tsx
+++ b/src/components/Routes.tsx
@@ -4,6 +4,7 @@ import { Route, Switch, useHistory } from 'react-router-dom';
 import { ROUTES } from 'routes';
 import Logger from 'utils/Logger';
 import { LandingPage } from './pages/LandingPage';
+import { StoragePage } from './pages/storage';
 import {
   DomainsCheckoutPage,
   MyDomainsPage,
@@ -32,6 +33,7 @@ const Routes = () => {
   return (
     <Switch>
       <Route exact path={ROUTES.LANDING} component={LandingPage} />
+      <Route exact path={ROUTES.STORAGE} component={StoragePage} />
       <Route exact path={ROUTES.DOMAINS.BUY} component={DomainOffersPage} />
       <Route exact path={ROUTES.DOMAINS.SELL} component={MyDomainsPage} />
       <Route exact path={ROUTES.DOMAINS.CHECKOUT.BUY} component={DomainOffersCheckoutPage} />

--- a/src/components/atoms/Login.tsx
+++ b/src/components/atoms/Login.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { Account, Web3Provider } from '@rsksmart/rif-ui';
-import { ButtonProps } from '@rsksmart/rif-ui/dist/components/atoms/buttons/Button';
 
-const Login = (props: ButtonProps) => (
+const Login = () => (
     <Web3Provider.Consumer>
         {({ state: { web3, networkName, account }, actions: { setProvider } }) => (
             <Account
@@ -10,7 +9,6 @@ const Login = (props: ButtonProps) => (
                 networkName={networkName}
                 account={account}
                 setProvider={setProvider}
-                {...props}
             />
         )}
     </Web3Provider.Consumer>

--- a/src/components/atoms/LoginModal.tsx
+++ b/src/components/atoms/LoginModal.tsx
@@ -1,0 +1,23 @@
+import React, { FC } from 'react';
+import { AccountModal, Web3Provider } from '@rsksmart/rif-ui';
+
+export interface LoginModalProps {
+  open: boolean;
+  handleClose: () => void;
+}
+
+const LoginModal: FC<LoginModalProps> = ({ open, handleClose }) => (
+  <Web3Provider.Consumer>
+    {({ state: { web3, networkName }, actions: { setProvider } }) => (
+      <AccountModal
+        web3={web3}
+        networkName={networkName}
+        open={open}
+        handleClose={handleClose}
+        setProvider={setProvider}
+      />
+    )}
+  </Web3Provider.Consumer>
+);
+
+export default LoginModal;

--- a/src/components/organisms/Footer.tsx
+++ b/src/components/organisms/Footer.tsx
@@ -20,60 +20,83 @@ const Footer = () => {
         title: 'RIF',
         links: [{
           title: 'Services',
-          to: 'https://developers.rsk.co/rif/'
+          to: 'https://developers.rsk.co/rif/',
+          isExternal: true
         },
         {
           title: 'Whitepaper',
-          to: 'https://developers.rsk.co/rif/'
+          to: 'https://developers.rsk.co/rif/',
+          target: '_blank',
+          isExternal: true
         },
         {
           title: 'RIF token',
-          to: 'https://developers.rsk.co/rif/'
+          to: 'https://developers.rsk.co/rif/',
+          target: '_blank',
+          isExternal: true
         }]
       },
       {
         title: 'RIF Marketplace',
         links: [{
           title: 'Services',
-          to: 'https://developers.rsk.co/rif/'
+          to: 'https://developers.rsk.co/rif/',
+          target: '_blank',
+          isExternal: true
         },
         {
           title: 'Whitepaper',
-          to: 'https://developers.rsk.co/rif/'
+          to: 'https://developers.rsk.co/rif/',
+          target: '_blank',
+          isExternal: true
         },
         {
           title: 'RIF token',
-          to: 'https://developers.rsk.co/rif/'
+          to: 'https://developers.rsk.co/rif/',
+          target: '_blank',
+          isExternal: true
         }]
       },
       {
         title: 'Developers',
         links: [{
           title: 'Services',
-          to: 'https://developers.rsk.co/rif/'
+          to: 'https://developers.rsk.co/rif/',
+          target: '_blank',
+          isExternal: true
         },
         {
           title: 'Whitepaper',
-          to: 'https://developers.rsk.co/rif/'
+          to: 'https://developers.rsk.co/rif/',
+          target: '_blank',
+          isExternal: true
         },
         {
           title: 'RIF token',
-          to: 'https://developers.rsk.co/rif/'
+          to: 'https://developers.rsk.co/rif/',
+          target: '_blank',
+          isExternal: true
         }]
       },
       {
         title: 'Privacy',
         links: [{
           title: 'Services',
-          to: 'https://developers.rsk.co/rif/'
+          to: 'https://developers.rsk.co/rif/',
+          target: '_blank',
+          isExternal: true
         },
         {
           title: 'Whitepaper',
-          to: 'https://developers.rsk.co/rif/'
+          to: 'https://developers.rsk.co/rif/',
+          target: '_blank',
+          isExternal: true
         },
         {
           title: 'RIF token',
-          to: 'https://developers.rsk.co/rif/'
+          to: 'https://developers.rsk.co/rif/',
+          target: '_blank',
+          isExternal: true
         }]
       }
     ]

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -3,9 +3,6 @@ import { ROUTES } from 'routes';
 import { Header as RUIHeader } from '@rsksmart/rif-ui';
 // TODO: remove the dist path once it's ready in the library
 import { HeaderItemProps } from '@rsksmart/rif-ui/dist/components/organisms/Header/Header';
-import AccountBalanceWalletIcon from '@material-ui/icons/AccountBalanceWallet';
-import DataUsageIcon from '@material-ui/icons/DataUsage';
-import ForumIcon from '@material-ui/icons/Forum';
 import PeopleIcon from '@material-ui/icons/People';
 import StorageIcon from '@material-ui/icons/Storage';
 import Login from 'components/atoms/Login';
@@ -25,21 +22,6 @@ const Header = () => {
       to: ROUTES.STORAGE,
       icon: <StorageIcon />
     },
-    {
-      title: 'Payments',
-      to: ROUTES.PAYMENTS,
-      icon: <AccountBalanceWalletIcon />
-    },
-    {
-      title: 'Data Services',
-      to: ROUTES.DATA_SERVICE,
-      icon: <DataUsageIcon />
-    },
-    {
-      title: 'Communications',
-      to: ROUTES.COMMUNICATIONS,
-      icon: <ForumIcon />
-    }
   ];
 
   return (<RUIHeader hreflogo={ROUTES.LANDING} items={headerItems} login={Login} />)

--- a/src/components/organisms/ServiceCategories.tsx
+++ b/src/components/organisms/ServiceCategories.tsx
@@ -44,8 +44,8 @@ const ServiceCategories: FC<ServiceCategoriesProps> = () => {
     <Grid container className={classes.servicesContainer}>
       {!!availableServices.length &&
         availableServices.map((service, i) => (
-          <Grid className={classes.serviceContent} item xs={12} lg={6}>
-            <IconedItem {...service} key={i} />
+          <Grid className={classes.serviceContent} item xs={12} lg={6} key={`g${i}`}>
+            <IconedItem {...service} key={`i${i}`} />
           </Grid>
         ))}
     </Grid>

--- a/src/components/organisms/filters/DomainFilters.tsx
+++ b/src/components/organisms/filters/DomainFilters.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext } from "react";
 import { MARKET_ACTIONS } from "store/Market/marketActions";
 import MarketStore from "store/Market/MarketStore";
 import RadioFilter from "./RadioFilter";

--- a/src/components/pages/rns/buy/DomainOffersCheckoutPage.tsx
+++ b/src/components/pages/rns/buy/DomainOffersCheckoutPage.tsx
@@ -212,7 +212,7 @@ const DomainOffersCheckoutPage = () => {
                             rounded shadow onClick={handleBuyDomain}>Buy domain</Button>
                     </CardActions>
                 }
-                {!account && <Login color='primary' variant='contained' rounded shadow />}
+                {!account && <Login />}
             </Card>
             {!!isProcessing && <TransactionInProgressPanel text='Buying the domain!' progMsg='The waiting period is required to securely buy your domain. Please do not close this tab until the process has finished.' />}
         </CheckoutPageTemplate >

--- a/src/components/pages/rns/sell/MyDomainsPage.tsx
+++ b/src/components/pages/rns/sell/MyDomainsPage.tsx
@@ -41,6 +41,7 @@ const MyDomainsPage = () => {
       })
     }
   }, [servicePath, account, dispatch])
+
   useEffect(() => {
     if (!servicePath && account) {
       const serviceAddr = createDomainService(account);

--- a/src/components/pages/storage/StoragePage.tsx
+++ b/src/components/pages/storage/StoragePage.tsx
@@ -1,0 +1,25 @@
+import React, { FC } from 'react';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+import { Typography, fonts } from '@rsksmart/rif-ui';
+
+export interface StoragePageProps { };
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    alignItems: 'center',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+}));
+
+const StoragePage: FC<StoragePageProps> = () => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.root}>
+      <Typography color='primary' variant='h1'>Storage empty page</Typography>
+    </div>
+  );
+};
+
+export default StoragePage;

--- a/src/components/pages/storage/index.ts
+++ b/src/components/pages/storage/index.ts
@@ -1,0 +1,3 @@
+import StoragePage from './StoragePage';
+
+export { StoragePage };

--- a/src/components/templates/marketplace/MarketFilter.tsx
+++ b/src/components/templates/marketplace/MarketFilter.tsx
@@ -1,10 +1,11 @@
 import { createStyles, makeStyles, Theme } from '@material-ui/core';
-import React, { FC, useContext } from 'react';
+import React, { FC, useContext, useEffect, useState } from 'react';
 import { useHistory } from 'react-router';
-import { colors, Grid, SwitchTabs, Typography } from '@rsksmart/rif-ui';
+import { colors, Grid, SwitchTabs, Typography, Web3Store } from '@rsksmart/rif-ui';
 import { ROUTES } from 'routes';
 import { MARKET_ACTIONS } from 'store/Market/marketActions';
 import MarketStore, { TxType } from 'store/Market/MarketStore';
+import LoginModal from '../../atoms/LoginModal';
 
 export interface MarketFilterProps { }
 
@@ -20,6 +21,7 @@ const useStyles = makeStyles((theme: Theme) =>
       },
       [theme.breakpoints.up('md')]: {
         height: '100%',
+        minHeight: theme.spacing(60),
       },
     },
     formHeading: {
@@ -41,31 +43,66 @@ const MarketFilter: FC<MarketFilterProps> = ({ children }) => {
     },
     dispatch
   } = useContext(MarketStore);
+
+  const {
+    state: { account },
+  } = useContext(Web3Store);
+
+  // TODO: fix this code. `isSwitching` watches for changes on the account 
+  // so we can wait until the account gets updated to switch the tab
+  const [isSwitching, setIsSwitching] = useState(false);
+  const [modalOpened, setModalOpened] = useState(false);
   const history = useHistory();
   const txType = currentListing?.txType;
 
+  const handleCloseModal = () => {
+    setModalOpened(false);
+    setIsSwitching(false);
+  }
+
   const handleSwitchChange = (): void => {
+    if (txType === TxType.BUY && !account) {
+      setIsSwitching(true);
+      setModalOpened(true);
+    }
+    else {
+      switchTxType();
+    }
+  }
+
+  const switchTxType = () => {
+    setIsSwitching(false);
     dispatch({
       type: MARKET_ACTIONS.TOGGLE_TX_TYPE,
       payload: {
         txType: txType === TxType.BUY ? TxType.SELL : TxType.BUY
       }
-    })
-    history.replace(txType === TxType.BUY ? ROUTES.DOMAINS.SELL : ROUTES.DOMAINS.BUY)
+    });
+    history.replace(txType === TxType.BUY ? ROUTES.DOMAINS.SELL : ROUTES.DOMAINS.BUY);
   }
 
+  // TODO: to be removed when finding a better solution
+  useEffect(() => {
+    if (account && isSwitching) {
+      switchTxType();
+    }
+  }, [account, isSwitching, switchTxType]);
+
   return (
-    <div className={classes.filter}>
-      <Grid className={classes.formHeading} container>
-        <Grid item xs={6}>
-          <Typography weight='lightBold' variant='h6' color='primary'>Domains</Typography>
+    <>
+      <LoginModal open={modalOpened} handleClose={handleCloseModal} />
+      <div className={classes.filter}>
+        <Grid className={classes.formHeading} container>
+          <Grid item xs={6}>
+            <Typography weight='lightBold' variant='h6' color='primary'>Domains</Typography>
+          </Grid>
+          <Grid className={classes.switchContainer} item xs={6}>
+            <SwitchTabs label1='Buy' label2='Sell' value={txType} onChange={handleSwitchChange} />
+          </Grid>
         </Grid>
-        <Grid className={classes.switchContainer} item xs={6}>
-          <SwitchTabs label1='Buy' label2='Sell' value={txType} onChange={handleSwitchChange} />
-        </Grid>
-      </Grid>
-      {children}
-    </div>
+        {children}
+      </div>
+    </>
   );
 };
 

--- a/src/components/templates/marketplace/Marketplace.tsx
+++ b/src/components/templates/marketplace/Marketplace.tsx
@@ -33,7 +33,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   th: {
     color: colors.gray6,
     fontWeight: fonts.weight.normal,
-    textAlign: 'center',
+    textAlign: 'left',
     textTransform: 'uppercase',
   },
   'tc-domain': {


### PR DESCRIPTION
This PR solves #54, #61 and #83 .

- When clicking on sell domains and not logged in, triggers the modal to log in.
- Consumes the new components on `rif-ui` to handle the Account Modal from another React element.
- Updated footer props to match the new `rif-ui` properties
- Removes elements we do not want to show yet in the Header
- Adds min-height to the Filters on desktop
- Created empty Storage Page

## Known issues
- The solution to trigger the modal when switching to the sell domains tab needs to be improved