### PR TITLE
fix: adds latest rif-ui in the lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2202,7 +2202,7 @@
       }
     },
     "@rsksmart/rif-ui": {
-      "version": "github:rsksmart/rif-ui#e08fe5f054badbf4b07de6e4ec8332579d3234f5",
+      "version": "github:rsksmart/rif-ui#8da1773c3eaca27c6041b48c6004f5c227edf22b",
       "from": "github:rsksmart/rif-ui"
     },
     "@samverschueren/stream-to-observable": {


### PR DESCRIPTION
Just an updated package-lock file.