### PR TITLE
feat: Canceling Domain functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2191,7 +2191,7 @@
       }
     },
     "@rsksmart/rif-ui": {
-      "version": "github:rsksmart/rif-ui#8da1773c3eaca27c6041b48c6004f5c227edf22b",
+      "version": "github:rsksmart/rif-ui#fdfdd2de1302e3704647ba7cdf875a0c7438b6e0",
       "from": "github:rsksmart/rif-ui"
     },
     "@samverschueren/stream-to-observable": {
@@ -13825,9 +13825,9 @@
       "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q="
     },
     "http-proxy": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
-      "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "requires": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",

--- a/src/components/Routes.tsx
+++ b/src/components/Routes.tsx
@@ -15,9 +15,9 @@ import {
   DomainOffersCheckoutPage,
   DomainListed,
   CancelDomainCheckoutPage,
-  DomainCanceled
+  DomainCanceled,
+  SoldDomainsPage
 } from './pages/rns';
-import SoldDomainsPage from './pages/rns/sell/SoldDomainsPage';
 
 
 const logger = Logger.getInstance();

--- a/src/components/Routes.tsx
+++ b/src/components/Routes.tsx
@@ -8,11 +8,17 @@ import { FAQPage } from './pages/faq';
 import { StoragePage } from './pages/storage';
 import AboutPage from './pages/AboutPage';
 import {
-  MyDomainsPage, DomainListed,
-  DomainsCheckoutPage, DomainOffersCheckoutPage,
-  SoldDomainsPage, DomainOffersPage,
-  DomainPurchased
-} from './pages'
+  DomainsCheckoutPage,
+  MyDomainsPage,
+  DomainOffersPage,
+  DomainPurchased,
+  DomainOffersCheckoutPage,
+  DomainListed,
+  CancelDomainCheckoutPage,
+  DomainCanceled
+} from './pages/rns';
+import SoldDomainsPage from './pages/rns/sell/SoldDomainsPage';
+
 
 const logger = Logger.getInstance();
 
@@ -39,8 +45,10 @@ const Routes = () => {
       <Route exact path={ROUTES.DOMAINS.CHECKOUT.BUY} component={DomainOffersCheckoutPage} />
       <Route exact path={ROUTES.DOMAINS.SELL} component={MyDomainsPage} />
       <Route exact path={ROUTES.DOMAINS.CHECKOUT.SELL} component={DomainsCheckoutPage} />
+      <Route exact path={ROUTES.DOMAINS.CHECKOUT.CANCEL} component={CancelDomainCheckoutPage} />
       <Route exact path={ROUTES.DOMAINS.DONE.SELL} component={DomainListed} />
       <Route exact path={ROUTES.DOMAINS.DONE.BUY} component={DomainPurchased} />
+      <Route exact path={ROUTES.DOMAINS.DONE.CANCEL} component={DomainCanceled} />
       <Route exact path={ROUTES.ABOUT} component={AboutPage} />
       <Route component={NotFound} />
     </Switch>

--- a/src/components/pages/rns/cancel/CancelDomainCheckoutPage.tsx
+++ b/src/components/pages/rns/cancel/CancelDomainCheckoutPage.tsx
@@ -1,0 +1,206 @@
+import React, { useContext, useEffect } from 'react';
+import { createStyles, makeStyles, Theme } from '@material-ui/core';
+import ERC721 from '@rsksmart/erc721/ERC721Data.json';
+import ERC721SimplePlacements from '@rsksmart/rif-marketplace-nfts/ERC721SimplePlacementsABI.json';
+import CombinedPriceCell from 'components/molecules/CombinedPriceCell';
+import TransactionInProgressPanel from 'components/organisms/TransactionInProgressPanel';
+import CheckoutPageTemplate from 'components/templates/CheckoutPageTemplate';
+import { useHistory } from 'react-router-dom';
+import { Button, Card, CardActions, CardContent, CardHeader, colors, Table, TableBody, TableCell, TableRow, Typography, Web3Store } from '@rsksmart/rif-ui';
+import { ROUTES } from 'routes';
+import { MARKET_ACTIONS } from 'store/Market/marketActions';
+import MarketStore from 'store/Market/MarketStore';
+import { ContractWrapper } from 'utils/blockchain.utils';
+import Web3 from 'web3';
+import contractAdds from 'ui-config.json';
+import Logger from 'utils/Logger';
+import AddressItem from 'components/molecules/AddressItem';
+import { shortenAddress } from "@rsksmart/rif-ui";
+const logger = Logger.getInstance();
+
+const NETWORK: string = process.env.REACT_APP_NETWORK || 'ganache';
+const rnsAddress = contractAdds[NETWORK].rnsDotRskOwner.toLowerCase();
+const marketPlaceAddress = contractAdds[NETWORK].marketplace.toLowerCase();
+
+const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        card: {
+            width: 491,
+            height: "fit-content",
+            padding: 80,
+            paddingTop: 44,
+            paddingBottom: 69,
+
+            background: colors.white,
+            border: `1px solid ${colors.gray1}`,
+            boxSizing: 'border-box',
+            boxShadow: '0px 6px 10px rgba(0, 0, 0, 0.2)',
+
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifySelf: 'center',
+            alignSelf: 'center',
+        },
+        contentTitle: {
+            marginBottom: theme.spacing(1),
+            textAlign: 'center',
+        },
+        footer: {
+            display: 'flex',
+            flexDirection: 'column',
+            alignContent: 'center',
+            textAlign: 'center'
+        },
+        contentDetails: {
+            width: 300,
+            display: 'flex',
+            flexDirection: 'column',
+        },
+        detailKey: {
+            border: 'none',
+        },
+        detailValue: {
+            border: 'none',
+        },
+    }),
+);
+
+const CancelDomainCheckoutPage = () => {
+  const history = useHistory();
+  const {
+    state: {
+      currentOrder,
+      exchangeRates: {
+        currentFiat,
+        crypto,
+      }
+    },
+    dispatch
+  } = useContext(MarketStore)
+  const classes = useStyles();
+  const {
+    state: {
+      account,
+      web3
+    }
+  } = useContext(Web3Store);
+  const Contract = (contract) => ContractWrapper(contract, (web3 as Web3), (account as string));
+
+  // Redirect direct link
+  useEffect(() => {
+    if (!currentOrder) {
+      history.replace(ROUTES.LANDING);
+    }
+  }, [currentOrder, history])
+
+  if (!currentOrder) return null;
+
+  const {
+    item: {
+      name,
+      expirationDate,
+      tokenId,
+      offer
+    },
+    isProcessing
+  } = currentOrder;
+
+  const currency = crypto[offer.paymentToken];
+
+  const priceCellProps = {
+      price: offer.price,
+      priceFiat: (currency.rate * offer.price).toString(),
+      currency: currency.displayName,
+      currencyFiat: currentFiat.displayName,
+      divider: ' '
+  };
+  const PriceCell = <CombinedPriceCell {...priceCellProps} />
+
+  const details = {
+    'NAME': name || <AddressItem pretext='Unknown RNS:' value={tokenId} />,
+    'RENEWAL DATE': expirationDate.toLocaleDateString(),
+    'PRICE': PriceCell
+}
+
+
+  const handleSubmit = async () => {
+    if (web3 && account) {
+      dispatch({
+        type: MARKET_ACTIONS.SELECT_ITEM,
+        payload: {
+          ...currentOrder,
+          isProcessing: true,
+        }
+      })
+      const rnsContract = await Contract(ERC721).at(rnsAddress)
+      const marketPlaceContract = await Contract({ abi: ERC721SimplePlacements }).at(marketPlaceAddress)
+
+      try {
+      
+        //Unapprove token
+        const unapproveReceipt = await rnsContract.approve("0x0000000000000000000000000000000000000000", tokenId)
+        logger.info('unapproveReciept:', unapproveReceipt);
+
+
+        const receipt = await marketPlaceContract.unplace(tokenId)
+        logger.info('unplace receipt:', receipt);
+
+        dispatch({
+          type: MARKET_ACTIONS.SELECT_ITEM,
+          payload: {
+            ...currentOrder,
+            isProcessing: false,
+          }
+        })
+        history.replace(ROUTES.DOMAINS.DONE.CANCEL)
+      } catch (e) {
+        logger.error('Could not complete transaction:', e)
+        history.replace(ROUTES.DOMAINS.SELL)
+        dispatch({
+          type: MARKET_ACTIONS.SELECT_ITEM,
+          payload: undefined,
+        })
+      }
+    }
+  }
+
+  return (
+    <CheckoutPageTemplate
+      className='domains-checkout-page'
+      backButtonProps={{
+        backTo: 'domains',
+        onClick: () => { }
+      }}
+    >
+      <Card
+          className={classes.card}
+      >
+          <CardHeader titleTypographyProps={{ variant: 'h5', color: 'primary' }} title={`Canceling ${name || shortenAddress(tokenId)}`} />
+          <CardContent>
+              <Typography className={classes.contentTitle} variant='h6' color='secondary'>Domain details</Typography>
+              <Table className={classes.contentDetails}>
+                  <TableBody>
+                      {Object.keys(details).map((key) => {
+                          return <TableRow key={key}>
+                              <TableCell className={classes.detailKey}>{key}</TableCell>
+                              <TableCell className={classes.detailValue}>{details[key]}</TableCell>
+                          </TableRow>
+                      })}
+              </TableBody>
+            </Table>
+          </CardContent>
+        {!isProcessing &&
+          <CardActions className={classes.footer}>
+            <p>Your wallet will open and you will be asked to confirm the transaction for canceling the domain.</p>
+            <Button color='primary' variant='contained'
+              rounded shadow onClick={handleSubmit}>Cancel domain</Button>
+          </CardActions>
+        }
+      </Card>
+      {isProcessing && <TransactionInProgressPanel text='Canceling the domain!' progMsg='The waiting period is required to securely cancel your domain listing. Please do not close this tab until the process has finished' />}
+    </CheckoutPageTemplate >
+  );
+};
+
+export default CancelDomainCheckoutPage;

--- a/src/components/pages/rns/cancel/CancelDomainCheckoutPage.tsx
+++ b/src/components/pages/rns/cancel/CancelDomainCheckoutPage.tsx
@@ -6,7 +6,7 @@ import CombinedPriceCell from 'components/molecules/CombinedPriceCell';
 import TransactionInProgressPanel from 'components/organisms/TransactionInProgressPanel';
 import CheckoutPageTemplate from 'components/templates/CheckoutPageTemplate';
 import { useHistory } from 'react-router-dom';
-import { Button, Card, CardActions, CardContent, CardHeader, colors, Table, TableBody, TableCell, TableRow, Typography, Web3Store } from '@rsksmart/rif-ui';
+import { Button, Card, CardActions, CardContent, CardHeader, colors, shortenAddress, Table, TableBody, TableCell, TableRow, Typography, Web3Store } from '@rsksmart/rif-ui';
 import { ROUTES } from 'routes';
 import { MARKET_ACTIONS } from 'store/Market/marketActions';
 import MarketStore from 'store/Market/MarketStore';
@@ -15,7 +15,6 @@ import Web3 from 'web3';
 import contractAdds from 'ui-config.json';
 import Logger from 'utils/Logger';
 import AddressItem from 'components/molecules/AddressItem';
-import { shortenAddress } from "@rsksmart/rif-ui";
 const logger = Logger.getInstance();
 
 const NETWORK: string = process.env.REACT_APP_NETWORK || 'ganache';
@@ -23,47 +22,47 @@ const rnsAddress = contractAdds[NETWORK].rnsDotRskOwner.toLowerCase();
 const marketPlaceAddress = contractAdds[NETWORK].marketplace.toLowerCase();
 
 const useStyles = makeStyles((theme: Theme) =>
-    createStyles({
-        card: {
-            width: 491,
-            height: "fit-content",
-            padding: 80,
-            paddingTop: 44,
-            paddingBottom: 69,
+  createStyles({
+    card: {
+      width: 491,
+      height: "fit-content",
+      padding: theme.spacing(10),
+      paddingTop: theme.spacing(5.5),
+      paddingBottom: theme.spacing(8.5),
 
-            background: colors.white,
-            border: `1px solid ${colors.gray1}`,
-            boxSizing: 'border-box',
-            boxShadow: '0px 6px 10px rgba(0, 0, 0, 0.2)',
+      background: colors.white,
+      border: `1px solid ${colors.gray1}`,
+      boxSizing: 'border-box',
+      boxShadow: '0px 6px 10px rgba(0, 0, 0, 0.2)',
 
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifySelf: 'center',
-            alignSelf: 'center',
-        },
-        contentTitle: {
-            marginBottom: theme.spacing(1),
-            textAlign: 'center',
-        },
-        footer: {
-            display: 'flex',
-            flexDirection: 'column',
-            alignContent: 'center',
-            textAlign: 'center'
-        },
-        contentDetails: {
-            width: 300,
-            display: 'flex',
-            flexDirection: 'column',
-        },
-        detailKey: {
-            border: 'none',
-        },
-        detailValue: {
-            border: 'none',
-        },
-    }),
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifySelf: 'center',
+      alignSelf: 'center',
+    },
+    contentTitle: {
+      marginBottom: theme.spacing(1),
+      textAlign: 'center',
+    },
+    footer: {
+      display: 'flex',
+      flexDirection: 'column',
+      alignContent: 'center',
+      textAlign: 'center'
+    },
+    contentDetails: {
+      width: 300,
+      display: 'flex',
+      flexDirection: 'column',
+    },
+    detailKey: {
+      border: 'none',
+    },
+    detailValue: {
+      border: 'none',
+    },
+  }),
 );
 
 const CancelDomainCheckoutPage = () => {
@@ -109,11 +108,11 @@ const CancelDomainCheckoutPage = () => {
   const currency = crypto[offer.paymentToken];
 
   const priceCellProps = {
-      price: offer.price,
-      priceFiat: (currency.rate * offer.price).toString(),
-      currency: currency.displayName,
-      currencyFiat: currentFiat.displayName,
-      divider: ' '
+    price: offer.price,
+    priceFiat: (currency.rate * offer.price).toString(),
+    currency: currency.displayName,
+    currencyFiat: currentFiat.displayName,
+    divider: ' '
   };
   const PriceCell = <CombinedPriceCell {...priceCellProps} />
 
@@ -121,8 +120,7 @@ const CancelDomainCheckoutPage = () => {
     'NAME': name || <AddressItem pretext='Unknown RNS:' value={tokenId} />,
     'RENEWAL DATE': expirationDate.toLocaleDateString(),
     'PRICE': PriceCell
-}
-
+  }
 
   const handleSubmit = async () => {
     if (web3 && account) {
@@ -137,11 +135,10 @@ const CancelDomainCheckoutPage = () => {
       const marketPlaceContract = await Contract({ abi: ERC721SimplePlacements }).at(marketPlaceAddress)
 
       try {
-      
+
         //Unapprove token
         const unapproveReceipt = await rnsContract.approve("0x0000000000000000000000000000000000000000", tokenId)
         logger.info('unapproveReciept:', unapproveReceipt);
-
 
         const receipt = await marketPlaceContract.unplace(tokenId)
         logger.info('unplace receipt:', receipt);
@@ -174,22 +171,22 @@ const CancelDomainCheckoutPage = () => {
       }}
     >
       <Card
-          className={classes.card}
+        className={classes.card}
       >
-          <CardHeader titleTypographyProps={{ variant: 'h5', color: 'primary' }} title={`Canceling ${name || shortenAddress(tokenId)}`} />
-          <CardContent>
-              <Typography className={classes.contentTitle} variant='h6' color='secondary'>Domain details</Typography>
-              <Table className={classes.contentDetails}>
-                  <TableBody>
-                      {Object.keys(details).map((key) => {
-                          return <TableRow key={key}>
-                              <TableCell className={classes.detailKey}>{key}</TableCell>
-                              <TableCell className={classes.detailValue}>{details[key]}</TableCell>
-                          </TableRow>
-                      })}
-              </TableBody>
-            </Table>
-          </CardContent>
+        <CardHeader titleTypographyProps={{ variant: 'h5', color: 'primary' }} title={`Canceling ${name || shortenAddress(tokenId)}`} />
+        <CardContent>
+          <Typography className={classes.contentTitle} variant='h6' color='secondary'>Domain details</Typography>
+          <Table className={classes.contentDetails}>
+            <TableBody>
+              {Object.keys(details).map((key) => {
+                return <TableRow key={key}>
+                  <TableCell className={classes.detailKey}>{key}</TableCell>
+                  <TableCell className={classes.detailValue}>{details[key]}</TableCell>
+                </TableRow>
+              })}
+            </TableBody>
+          </Table>
+        </CardContent>
         {!isProcessing &&
           <CardActions className={classes.footer}>
             <p>Your wallet will open and you will be asked to confirm the transaction for canceling the domain.</p>

--- a/src/components/pages/rns/cancel/DomainCanceled.tsx
+++ b/src/components/pages/rns/cancel/DomainCanceled.tsx
@@ -1,0 +1,47 @@
+import { createStyles, makeStyles, Theme } from '@material-ui/core';
+import { Button } from '@rsksmart/rif-ui';
+import JobDoneBox from 'components/molecules/JobDoneBox';
+import TxCompletePageTemplate from 'components/templates/TxCompletePageTemplate';
+import React, { FC } from 'react';
+import { useHistory } from 'react-router';
+import { ROUTES } from 'routes';
+
+const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        actions: {
+            display: 'flex',
+            justifyContent: 'space-between',
+            flexDirection: 'row',
+            padding: '3em',
+            width: 355,
+        }
+    }),
+);
+
+const DomainCanceled: FC<{}> = () => {
+    const classes = useStyles();
+    const history = useHistory();
+
+    return (
+        <TxCompletePageTemplate>
+            <JobDoneBox text='Your domain has been canceled.' />
+            {/* <a href=''>Check it in the explorer</a> */}
+            <div className={classes.actions}>
+                <Button
+                    color='primary'
+                    variant='contained'
+                    rounded
+                    shadow
+                    onClick={() => { history.push(ROUTES.DOMAINS.SELL) }}>View my domains</Button>
+                <Button
+                    color='primary'
+                    variant='contained'
+                    rounded
+                    shadow
+                    onClick={() => { history.push(ROUTES.DOMAINS.BUY) }}>View domain listing</Button>
+            </div>
+        </TxCompletePageTemplate>
+    );
+}
+
+export default DomainCanceled;

--- a/src/components/pages/rns/cancel/index.ts
+++ b/src/components/pages/rns/cancel/index.ts
@@ -1,0 +1,7 @@
+import CancelDomainCheckoutPage from "./CancelDomainCheckoutPage";
+import DomainCanceled from "./DomainCanceled";
+
+export {
+    CancelDomainCheckoutPage,
+    DomainCanceled
+};

--- a/src/components/pages/rns/index.ts
+++ b/src/components/pages/rns/index.ts
@@ -1,2 +1,3 @@
 export * from './buy';
 export * from './sell';
+export * from './cancel';

--- a/src/components/pages/rns/sell/MyDomainsPage.tsx
+++ b/src/components/pages/rns/sell/MyDomainsPage.tsx
@@ -5,13 +5,14 @@ import MarketPageTemplate from 'components/templates/MarketPageTemplate';
 import { MarketListingTypes } from 'models/Market';
 import React, { FC, useContext, useEffect } from 'react';
 import { useHistory } from 'react-router';
-import { Web3Store } from '@rsksmart/rif-ui';
+import { Web3Store, IconButton } from '@rsksmart/rif-ui';
 import { ROUTES } from 'routes';
 import { MARKET_ACTIONS } from 'store/Market/marketActions';
 import MarketStore, { TxType } from 'store/Market/MarketStore';
 import { Domain } from 'models/marketItems/DomainItem';
 import AddressItem from 'components/molecules/AddressItem';
 import { CombinedPriceCell } from 'components/molecules';
+import ClearIcon from '@material-ui/icons/Clear';
 
 const LISTING_TYPE = MarketListingTypes.DOMAINS;
 const TX_TYPE = TxType.SELL;
@@ -100,7 +101,8 @@ const MyDomainsPage: FC<{}> = () => {
       name: 'Name',
       expirationDate: 'Renewal Date',
       price: 'Listed Price',
-      actionCol_1: ''
+      actionCol_1: '',
+      actionCol_2: ''
     },
     sold: {}
   }
@@ -145,6 +147,23 @@ const MyDomainsPage: FC<{}> = () => {
           currencyFiat={currentFiat.displayName}
           divider=' = '
         />
+        displayItem['actionCol_2']= <IconButton color='primary' 
+          id={_id}
+          onClick={() => {
+            dispatch({
+              type: MARKET_ACTIONS.SELECT_ITEM,
+              payload: {
+                listingType: LISTING_TYPE,
+                item: domainItem,
+                txType: TX_TYPE  
+              }
+            })
+            history.push(ROUTES.DOMAINS.CHECKOUT.CANCEL)
+          }}
+        ><ClearIcon /></IconButton>;
+        
+
+
       }
 
       return displayItem;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -10,6 +10,8 @@ const DOMAIN_OFFERS_CHECKOUT = `${DOMAINS_BUY}/checkout`
 const DOMAINS_CHECKOUT = `${DOMAINS_SELL}/checkout`
 const DOMAIN_OFFERS_DONE = `${DOMAINS_BUY}/done`
 const DOMAINS_DONE = `${DOMAINS_SELL}/done`
+const DOMAIN_CANCEL_CHECKOUT = `${DOMAINS}/cancel/checkout`
+const DOMAIN_CANCEL_DONE = `${DOMAINS}/cancel/done`
 const STORAGE = '/storage'
 const FAQ = '/faq'
 const ABOUT = '/about'
@@ -28,10 +30,12 @@ export const ROUTES = {
     CHECKOUT: {
       BUY: DOMAIN_OFFERS_CHECKOUT,
       SELL: DOMAINS_CHECKOUT,
+      CANCEL: DOMAIN_CANCEL_CHECKOUT
     },
     DONE: {
       BUY: DOMAIN_OFFERS_DONE,
-      SELL: DOMAINS_DONE
+      SELL: DOMAINS_DONE,
+      CANCEL: DOMAIN_CANCEL_DONE
     }
   },
   FAQ,


### PR DESCRIPTION
Main goal: Adds the Canceling a Domain functionality.

Changes:  
- Added IconButton X for Canceling a Listed Domain.
- Adapted routes and flow to be able to Cancel Domain (requires two transactions - The "unapproval" of the Token and the actual "unplace" Transaction)
- Two New pages:
   - rns/cancel/DomainCanceled.tsx
   - rns/cancel/CancelDomainCheckoutPage.tsx