### PR TITLE
refactor: moved faq stuff to rif-ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2191,7 +2191,7 @@
       }
     },
     "@rsksmart/rif-ui": {
-      "version": "github:rsksmart/rif-ui#60311cf31d91ffbb1a63924efd81da2561a51f28",
+      "version": "github:rsksmart/rif-ui#af7c95d739abbc2ee3c0256b1fc62d2b12abb975",
       "from": "github:rsksmart/rif-ui#feature/faq"
     },
     "@samverschueren/stream-to-observable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2191,8 +2191,8 @@
       }
     },
     "@rsksmart/rif-ui": {
-      "version": "github:rsksmart/rif-ui#af7c95d739abbc2ee3c0256b1fc62d2b12abb975",
-      "from": "github:rsksmart/rif-ui#feature/faq"
+      "version": "github:rsksmart/rif-ui#d0a8d5344e05c75884a85e94c6488e610d1dda54",
+      "from": "github:rsksmart/rif-ui"
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2192,7 +2192,7 @@
     },
     "@rsksmart/rif-ui": {
       "version": "github:rsksmart/rif-ui#d0a8d5344e05c75884a85e94c6488e610d1dda54",
-      "from": "github:rsksmart/rif-ui"
+      "from": "github:rsksmart/rif-ui#v0.0.2"
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2191,8 +2191,8 @@
       }
     },
     "@rsksmart/rif-ui": {
-      "version": "github:rsksmart/rif-ui#fdfdd2de1302e3704647ba7cdf875a0c7438b6e0",
-      "from": "github:rsksmart/rif-ui"
+      "version": "github:rsksmart/rif-ui#60311cf31d91ffbb1a63924efd81da2561a51f28",
+      "from": "github:rsksmart/rif-ui#feature/faq"
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@rsksmart/erc677": "^1.0.2",
     "@rsksmart/erc721": "^1.0.0",
     "@rsksmart/rif-marketplace-nfts": "0.0.2",
-    "@rsksmart/rif-ui": "github:rsksmart/rif-ui",
+    "@rsksmart/rif-ui": "github:rsksmart/rif-ui#v0.0.2",
     "@truffle/contract": "^4.2.5",
     "@truffle/debug-utils": "^4.1.3",
     "react": "^16.13.1",

--- a/src/components/Routes.tsx
+++ b/src/components/Routes.tsx
@@ -1,12 +1,10 @@
-import NotFound from 'components/pages/NotFound'
 import React, { useEffect } from 'react'
 import { Route, Switch, useHistory } from 'react-router-dom'
 import ROUTES from 'routes'
 import Logger from 'utils/Logger'
-import LandingPage from './pages/LandingPage'
-import FAQPage from './pages/faq/FAQPage'
 import StoragePage from './pages/storage/StoragePage'
-import AboutPage from './pages/AboutPage'
+
+import { AboutPage, FAQPage, LandingPage, NotFound } from './pages';
 import {
   DomainsCheckoutPage,
   MyDomainsPage,

--- a/src/components/Routes.tsx
+++ b/src/components/Routes.tsx
@@ -4,7 +4,9 @@ import ROUTES from 'routes'
 import Logger from 'utils/Logger'
 import StoragePage from './pages/storage/StoragePage'
 
-import { AboutPage, FAQPage, LandingPage, NotFound } from './pages';
+import {
+  AboutPage, FAQPage, LandingPage, NotFound,
+} from './pages'
 import {
   DomainsCheckoutPage,
   MyDomainsPage,

--- a/src/components/pages/FAQPage.tsx
+++ b/src/components/pages/FAQPage.tsx
@@ -1,12 +1,13 @@
-import React, { FC } from 'react';
+import React, { FC } from 'react'
 import {
   FAQPageTemplate,
-} from '@rsksmart/rif-ui';
-import { FAQPageTemplateProps } from '@rsksmart/rif-ui/dist/components/templates/FAQPageTemplate';
+} from '@rsksmart/rif-ui'
+/* eslint-disable-next-line import/no-unresolved */
+import { FAQPageTemplateProps } from '@rsksmart/rif-ui/dist/components/templates/FAQPageTemplate'
 
 export interface FAQPageProps {
-  className?: string;
-};
+  className?: string
+}
 
 const FAQPage: FC<{}> = () => {
   const faqTemplateProps: FAQPageTemplateProps = {
@@ -14,31 +15,31 @@ const FAQPage: FC<{}> = () => {
     questionsAndAnswers: [
       {
         question: 'What is the RIF Marketplace?',
-        answer: `RIF Marketplace provides a one-stop shop for a wide variety of decentralized services, presenting at the same time a common unified/simplified interface and user experience.  The RIF Marketplace allows Service Providers and Consumers to meet and engage in a secure and efficient way, includes staking, reputation, and slashing mechanisms, to ensure all parties fulfill their obligations as expected. `,
-        initiallyExpanded: false
+        answer: 'RIF Marketplace provides a one-stop shop for a wide variety of decentralized services, presenting at the same time a common unified/simplified interface and user experience.  The RIF Marketplace allows Service Providers and Consumers to meet and engage in a secure and efficient way, includes staking, reputation, and slashing mechanisms, to ensure all parties fulfill their obligations as expected. ',
+        initiallyExpanded: false,
       },
       {
         question: 'Which services are you planning to offer in the RIF Marketplace?',
         answer: `We plan to cover a wide range of services including Buying and Selling RNS Domains, Storage Services, Data Services (Oracles),
    Payments Services (Watchtowers), Trigger Services, Scheduling Services, Metatransaction providers (Gas Stations), and Notarization/Timestamping services, among others.`,
-        initiallyExpanded: false
+        initiallyExpanded: false,
       },
       {
         question: 'How do you compare to other Marketplaces?',
         answer: `Currently there are no decentralized Marketplaces that cover the variety of services we offer in the RIF Marketplace and that simplify access and consumption of these services as we do, providing a one-stop-shop to access all the required services to build decentralized applications and systems.
-    .`
+    .`,
       },
       {
         question: 'What are the main characteristics of the RIF Marketplace?',
         answer: `The main features of the RIF Marketplace include: 
     A) Decentralization  (including all the benefits associated such as security, transparency, censorship resistance, immutability and self-owned reputation, etc). 
     B) Wide range of services  (we cover all the required building blocks for developers to build Decentralized applications and systems including Storage, Communications, Payments, Data Services, and Meta-transactions).
-    C) Unified and Simplified interface: We have a strong focus in the end-user making it simple for them to consume the services and providing a unified and simplified interface to access multiple providers and technologies in each of the service categories.`
+    C) Unified and Simplified interface: We have a strong focus in the end-user making it simple for them to consume the services and providing a unified and simplified interface to access multiple providers and technologies in each of the service categories.`,
       },
       {
         question: 'How does it fit in with the rest of the RIF/RSK ecosystem and the DeFi ecosystem?',
         answer: `The RIF Marketplace is the heart of the RIF economy and will be the entry/access point to most of the RIF services such as Storage, Communications, Data Services, etc. Providers of the different RIF services will be able to list their offerings in the RIF Marketplace and engage with users/consumers in a secure and efficient way. 
-    At the same time the DeFi ecosystem will surely require services from the RIF Marketplace and allowing a seamless and efficient integration will be extremely important for any company, partner, or developer that wants to build a solution on top of the RSK/RIF suite of technologies.`
+    At the same time the DeFi ecosystem will surely require services from the RIF Marketplace and allowing a seamless and efficient integration will be extremely important for any company, partner, or developer that wants to build a solution on top of the RSK/RIF suite of technologies.`,
       },
       {
         question: 'What is the Roadmap for the RIF Marketplace in the short term?',
@@ -48,21 +49,21 @@ const FAQPage: FC<{}> = () => {
     RNS Domains (Buying and selling of RNS domains among users)
     Storage Pinning Services (Renting decentralized storage)
     
-    The next step is to add additional services (Oracles coming soon!) and also to incorporate the staking, slashing, SLA, reputation and dispute resolution mechanisms to ensure all parties have a positive and reliable experience.`
+    The next step is to add additional services (Oracles coming soon!) and also to incorporate the staking, slashing, SLA, reputation and dispute resolution mechanisms to ensure all parties have a positive and reliable experience.`,
 
       },
       {
         question: 'What are the long terms plans for the RIF Marketplace?',
-        answer: `In the long term we expect the RIF Marketplace not only to be one of the main sources for users and developers to access decentralized services, but also serve as the cornerstone and base for the creation/development of other decentralized marketplaces for many different use cases. The RIF Marketplace aims to be in the long term the foundation of multiple projects that would bring us closer to a more decentralized, inclusive, and fair world such as the one we envision in RIF.`
-      }
-    ]
+        answer: 'In the long term we expect the RIF Marketplace not only to be one of the main sources for users and developers to access decentralized services, but also serve as the cornerstone and base for the creation/development of other decentralized marketplaces for many different use cases. The RIF Marketplace aims to be in the long term the foundation of multiple projects that would bring us closer to a more decentralized, inclusive, and fair world such as the one we envision in RIF.',
+      },
+    ],
   }
 
   return (
     <FAQPageTemplate
       {...faqTemplateProps}
     />
-  );
-};
+  )
+}
 
-export default FAQPage;
+export default FAQPage

--- a/src/components/pages/FAQPage.tsx
+++ b/src/components/pages/FAQPage.tsx
@@ -13,26 +13,22 @@ const FAQPage: FC<{}> = () => {
     mainTitle: 'Frequently Asked Questions',
     questionsAndAnswers: [
       {
-        id: 'q1',
         question: 'What is the RIF Marketplace?',
         answer: `RIF Marketplace provides a one-stop shop for a wide variety of decentralized services, presenting at the same time a common unified/simplified interface and user experience.  The RIF Marketplace allows Service Providers and Consumers to meet and engage in a secure and efficient way, includes staking, reputation, and slashing mechanisms, to ensure all parties fulfill their obligations as expected. `,
-        initiallyExpanded: true
+        initiallyExpanded: false
       },
       {
-        id: 'q2',
         question: 'Which services are you planning to offer in the RIF Marketplace?',
         answer: `We plan to cover a wide range of services including Buying and Selling RNS Domains, Storage Services, Data Services (Oracles),
    Payments Services (Watchtowers), Trigger Services, Scheduling Services, Metatransaction providers (Gas Stations), and Notarization/Timestamping services, among others.`,
         initiallyExpanded: false
       },
       {
-        id: 'q3',
         question: 'How do you compare to other Marketplaces?',
         answer: `Currently there are no decentralized Marketplaces that cover the variety of services we offer in the RIF Marketplace and that simplify access and consumption of these services as we do, providing a one-stop-shop to access all the required services to build decentralized applications and systems.
     .`
       },
       {
-        id: 'q4',
         question: 'What are the main characteristics of the RIF Marketplace?',
         answer: `The main features of the RIF Marketplace include: 
     A) Decentralization  (including all the benefits associated such as security, transparency, censorship resistance, immutability and self-owned reputation, etc). 
@@ -40,13 +36,11 @@ const FAQPage: FC<{}> = () => {
     C) Unified and Simplified interface: We have a strong focus in the end-user making it simple for them to consume the services and providing a unified and simplified interface to access multiple providers and technologies in each of the service categories.`
       },
       {
-        id: 'q5',
         question: 'How does it fit in with the rest of the RIF/RSK ecosystem and the DeFi ecosystem?',
         answer: `The RIF Marketplace is the heart of the RIF economy and will be the entry/access point to most of the RIF services such as Storage, Communications, Data Services, etc. Providers of the different RIF services will be able to list their offerings in the RIF Marketplace and engage with users/consumers in a secure and efficient way. 
     At the same time the DeFi ecosystem will surely require services from the RIF Marketplace and allowing a seamless and efficient integration will be extremely important for any company, partner, or developer that wants to build a solution on top of the RSK/RIF suite of technologies.`
       },
       {
-        id: 'q6',
         question: 'What is the Roadmap for the RIF Marketplace in the short term?',
         answer: `We are releasing the first version of the RIF Marketplace to the RSK Testnet in May 2020.  
 
@@ -58,7 +52,6 @@ const FAQPage: FC<{}> = () => {
 
       },
       {
-        id: 'q7',
         question: 'What are the long terms plans for the RIF Marketplace?',
         answer: `In the long term we expect the RIF Marketplace not only to be one of the main sources for users and developers to access decentralized services, but also serve as the cornerstone and base for the creation/development of other decentralized marketplaces for many different use cases. The RIF Marketplace aims to be in the long term the foundation of multiple projects that would bring us closer to a more decentralized, inclusive, and fair world such as the one we envision in RIF.`
       }

--- a/src/components/pages/FAQPage.tsx
+++ b/src/components/pages/FAQPage.tsx
@@ -1,0 +1,75 @@
+import React, { FC } from 'react';
+import {
+  FAQPageTemplate,
+} from '@rsksmart/rif-ui';
+import { FAQPageTemplateProps } from '@rsksmart/rif-ui/dist/components/templates/FAQPageTemplate';
+
+export interface FAQPageProps {
+  className?: string;
+};
+
+const FAQPage: FC<{}> = () => {
+  const faqTemplateProps: FAQPageTemplateProps = {
+    mainTitle: 'Frequently Asked Questions',
+    questionsAndAnswers: [
+      {
+        id: 'q1',
+        question: 'What is the RIF Marketplace?',
+        answer: `RIF Marketplace provides a one-stop shop for a wide variety of decentralized services, presenting at the same time a common unified/simplified interface and user experience.  The RIF Marketplace allows Service Providers and Consumers to meet and engage in a secure and efficient way, includes staking, reputation, and slashing mechanisms, to ensure all parties fulfill their obligations as expected. `,
+        initiallyExpanded: true
+      },
+      {
+        id: 'q2',
+        question: 'Which services are you planning to offer in the RIF Marketplace?',
+        answer: `We plan to cover a wide range of services including Buying and Selling RNS Domains, Storage Services, Data Services (Oracles),
+   Payments Services (Watchtowers), Trigger Services, Scheduling Services, Metatransaction providers (Gas Stations), and Notarization/Timestamping services, among others.`,
+        initiallyExpanded: false
+      },
+      {
+        id: 'q3',
+        question: 'How do you compare to other Marketplaces?',
+        answer: `Currently there are no decentralized Marketplaces that cover the variety of services we offer in the RIF Marketplace and that simplify access and consumption of these services as we do, providing a one-stop-shop to access all the required services to build decentralized applications and systems.
+    .`
+      },
+      {
+        id: 'q4',
+        question: 'What are the main characteristics of the RIF Marketplace?',
+        answer: `The main features of the RIF Marketplace include: 
+    A) Decentralization  (including all the benefits associated such as security, transparency, censorship resistance, immutability and self-owned reputation, etc). 
+    B) Wide range of services  (we cover all the required building blocks for developers to build Decentralized applications and systems including Storage, Communications, Payments, Data Services, and Meta-transactions).
+    C) Unified and Simplified interface: We have a strong focus in the end-user making it simple for them to consume the services and providing a unified and simplified interface to access multiple providers and technologies in each of the service categories.`
+      },
+      {
+        id: 'q5',
+        question: 'How does it fit in with the rest of the RIF/RSK ecosystem and the DeFi ecosystem?',
+        answer: `The RIF Marketplace is the heart of the RIF economy and will be the entry/access point to most of the RIF services such as Storage, Communications, Data Services, etc. Providers of the different RIF services will be able to list their offerings in the RIF Marketplace and engage with users/consumers in a secure and efficient way. 
+    At the same time the DeFi ecosystem will surely require services from the RIF Marketplace and allowing a seamless and efficient integration will be extremely important for any company, partner, or developer that wants to build a solution on top of the RSK/RIF suite of technologies.`
+      },
+      {
+        id: 'q6',
+        question: 'What is the Roadmap for the RIF Marketplace in the short term?',
+        answer: `We are releasing the first version of the RIF Marketplace to the RSK Testnet in May 2020.  
+
+    This version is accessible via web and includes two main service categories:
+    RNS Domains (Buying and selling of RNS domains among users)
+    Storage Pinning Services (Renting decentralized storage)
+    
+    The next step is to add additional services (Oracles coming soon!) and also to incorporate the staking, slashing, SLA, reputation and dispute resolution mechanisms to ensure all parties have a positive and reliable experience.`
+
+      },
+      {
+        id: 'q7',
+        question: 'What are the long terms plans for the RIF Marketplace?',
+        answer: `In the long term we expect the RIF Marketplace not only to be one of the main sources for users and developers to access decentralized services, but also serve as the cornerstone and base for the creation/development of other decentralized marketplaces for many different use cases. The RIF Marketplace aims to be in the long term the foundation of multiple projects that would bring us closer to a more decentralized, inclusive, and fair world such as the one we envision in RIF.`
+      }
+    ]
+  }
+
+  return (
+    <FAQPageTemplate
+      {...faqTemplateProps}
+    />
+  );
+};
+
+export default FAQPage;

--- a/src/components/pages/faq/FAQPage.tsx
+++ b/src/components/pages/faq/FAQPage.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import { Typography, colors } from '@rsksmart/rif-ui'
 import FAQSection, { FAQSectionProps } from 'components/molecules/FAQSection'
-import FAQPageTemplate from '../../templates/FAQPageTemplate'
+import { FAQPageTemplate } from '@rsksmart/rif-ui';
 
 // TODO:
 // - create FAQSection in rif-ui

--- a/src/components/pages/faq/FAQPage.tsx
+++ b/src/components/pages/faq/FAQPage.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import { Typography, colors } from '@rsksmart/rif-ui'
+import { Typography, colors, FAQPageTemplate } from '@rsksmart/rif-ui'
 import FAQSection, { FAQSectionProps } from 'components/molecules/FAQSection'
-import { FAQPageTemplate } from '@rsksmart/rif-ui';
+
 
 // TODO:
 // - create FAQSection in rif-ui

--- a/src/components/pages/index.ts
+++ b/src/components/pages/index.ts
@@ -1,12 +1,12 @@
-import AboutPage from './AboutPage';
-import FAQPage from './FAQPage';
-import LandingPage from './LandingPage';
-import NotFound from './NotFound';
+import AboutPage from './AboutPage'
+import FAQPage from './FAQPage'
+import LandingPage from './LandingPage'
+import NotFound from './NotFound'
 
 export {
   AboutPage,
   FAQPage,
   LandingPage,
   NotFound,
-};
+}
 export * from './rns'

--- a/src/components/pages/index.ts
+++ b/src/components/pages/index.ts
@@ -1,1 +1,12 @@
+import AboutPage from './AboutPage';
+import FAQPage from './FAQPage';
+import LandingPage from './LandingPage';
+import NotFound from './NotFound';
+
+export {
+  AboutPage,
+  FAQPage,
+  LandingPage,
+  NotFound,
+};
 export * from './rns'


### PR DESCRIPTION
Closes #108 
Moved FAQ stuff to `rif-ui`.
This PR depends on [this PR from rif-ui](https://github.com/rsksmart/rif-ui/pull/45).
I would suggest to not merge this PR until the other one is merged so we can point to rif-ui master branch.