### PR TITLE
fix: Disable RNS Admin redirect button

### DIFF
--- a/src/components/pages/rns/buy/DomainPurchased.tsx
+++ b/src/components/pages/rns/buy/DomainPurchased.tsx
@@ -30,6 +30,7 @@ const DomainPurchased: FC<{}> = () => {
           variant="contained"
           rounded
           shadow
+          disabled
           onClick={() => { alert('This should take you to the RNS admin page.') }} // eslint-disable-line no-alert
         // FIXME: do the correct navigation here
         >


### PR DESCRIPTION
Disabling RNS Admin Redirect button until we implement this. The URL will depend on the environment, so would probably need to be included in the UI Config file for each network.