### PR TITLE
feat: adds support for events coming from cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2142,6 +2142,18 @@
         "@babel/runtime": "^7.4.4"
       }
     },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.54",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.54.tgz",
+      "integrity": "sha512-BK/z+8xGPQoMtG6gWKyagCdYO1/2DzkBchvvXs2bbTVh3sbi/QQLIqWV6UA1KtMVydYVt22NwV3xltgPkaPKLg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.9.6",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@feathersjs/socketio-client": "^4.5.4",
     "@material-ui/core": "^4.10.0",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.54",
     "@rsksmart/erc677": "^1.0.2",
     "@rsksmart/erc721": "^1.0.0",
     "@rsksmart/rif-marketplace-nfts": "0.0.2",

--- a/src/api/models/RnsFilter.ts
+++ b/src/api/models/RnsFilter.ts
@@ -11,8 +11,19 @@ export interface DomainOffersFilter extends MarketFilter {
             $like: string
         }
     }
-    sellerAddress?: {
+    ownerAddress?: {
         $ne: string
     }
 }
-export type DomainFilter = MarketFilter
+export interface DomainFilter extends MarketFilter {
+    ownerAddress: string
+    name?: {
+        $like: string
+    }
+    price?: {
+        $lte: number
+        $gte: number
+    }
+}
+
+export type RnsFilterType = DomainFilter & DomainOffersFilter

--- a/src/api/rif-marketplace-cache/cacheController.ts
+++ b/src/api/rif-marketplace-cache/cacheController.ts
@@ -14,16 +14,14 @@ client.configure(socketio(socket))
 const service = {
   current: null,
 }
+
 export const createService = (path: string, dispatch) => {
+  const setTokensForRefresh = (updatedTokenId) => {
+    dispatch({ type: MARKET_ACTIONS.SET_META, payload: { updatedTokenId } })
+  }
   const svc = client.service(path)
-  svc.on(['created', 'patched', 'updated'], (data, ctx) => {
-    console.log('data updated:', data);
-    dispatch({
-      type: MARKET_ACTIONS.SET_META, payload: {
-        isUpToDate: false,
-      }
-    })
-  })
+  svc.on('updated', (data) => setTokensForRefresh(data.tokenId))
+  svc.on('created', (data) => setTokensForRefresh(data.tokenId))
   service.current = svc
   return path
 }

--- a/src/api/rif-marketplace-cache/cacheController.ts
+++ b/src/api/rif-marketplace-cache/cacheController.ts
@@ -3,25 +3,27 @@ import socketio from '@feathersjs/socketio-client'
 import { MarketFilter } from 'models/Market'
 import io from 'socket.io-client'
 import { MARKET_ACTIONS } from 'store/Market/marketActions'
+import { RnsServicePaths } from './domainsController'
 
 const CACHE_BASE_ADDR = process.env.REACT_APP_CACHE_ADDR || 'http://localhost:3030'
 
 const socket = io(CACHE_BASE_ADDR)
 export const client = feathers()
 client.configure(socketio(socket))
-// <- extract
 
 const service = {
   current: null,
 }
 
-export const createService = (path: string, dispatch) => {
-  const setTokensForRefresh = (updatedTokenId) => {
+export const createService = (path: RnsServicePaths, dispatch) => {
+  const promptRefresh = (updatedTokenId) => {
     dispatch({ type: MARKET_ACTIONS.SET_META, payload: { updatedTokenId } })
   }
   const svc = client.service(path)
-  svc.on('updated', (data) => setTokensForRefresh(data.tokenId))
-  svc.on('created', (data) => setTokensForRefresh(data.tokenId))
+  svc.on('updated', ({ tokenId }) => promptRefresh(tokenId))
+  svc.on('patched', ({ tokenId }) => promptRefresh(tokenId))
+  svc.on('created', ({ tokenId }) => promptRefresh(tokenId))
+  svc.on('removed', ({ tokenId }) => promptRefresh(tokenId))
   service.current = svc
   return path
 }

--- a/src/api/rif-marketplace-cache/cacheController.ts
+++ b/src/api/rif-marketplace-cache/cacheController.ts
@@ -2,6 +2,7 @@ import feathers from '@feathersjs/feathers'
 import socketio from '@feathersjs/socketio-client'
 import { MarketFilter } from 'models/Market'
 import io from 'socket.io-client'
+import { MARKET_ACTIONS } from 'store/Market/marketActions'
 
 const CACHE_BASE_ADDR = process.env.REACT_APP_CACHE_ADDR || 'http://localhost:3030'
 
@@ -13,8 +14,17 @@ client.configure(socketio(socket))
 const service = {
   current: null,
 }
-export const createService = (path: string) => {
-  service.current = client.service(path)
+export const createService = (path: string, dispatch) => {
+  const svc = client.service(path)
+  svc.on(['created', 'patched', 'updated'], (data, ctx) => {
+    console.log('data updated:', data);
+    dispatch({
+      type: MARKET_ACTIONS.SET_META, payload: {
+        isUpToDate: false,
+      }
+    })
+  })
+  service.current = svc
   return path
 }
 

--- a/src/api/rif-marketplace-cache/domainsController.ts
+++ b/src/api/rif-marketplace-cache/domainsController.ts
@@ -108,11 +108,11 @@ const mappings = {
   sold: soldTransportMapper,
 }
 
-export const createDomainService = (ownerAddress: string) => createService(DOMAINS_SERVICE_PATHS.SELL(ownerAddress))
+export const createDomainService = (ownerAddress: string, marketDispatch) => createService(DOMAINS_SERVICE_PATHS.SELL(ownerAddress), marketDispatch)
 
-export const createOffersService = () => createService(DOMAINS_SERVICE_PATHS.BUY())
+export const createOffersService = (marketDispatch) => createService(DOMAINS_SERVICE_PATHS.BUY(), marketDispatch)
 
-export const createSoldService = (ownerAddress: string) => createService(DOMAINS_SERVICE_PATHS.SOLD(ownerAddress))
+export const createSoldService = (ownerAddress: string, marketDispatch) => createService(DOMAINS_SERVICE_PATHS.SOLD(ownerAddress), marketDispatch)
 
 export const fetchDomainOffers = async (filters: DomainOffersFilter) => {
   const { price } = filters

--- a/src/api/rif-marketplace-cache/domainsController.ts
+++ b/src/api/rif-marketplace-cache/domainsController.ts
@@ -142,9 +142,8 @@ export const fetchSoldDomains = async (filters?) => {
   return results.map(mappings.sold)
 }
 
-const fetchMinPrice = async (filters?) => {
+const fetchMinPrice = async () => {
   const query = {
-    ...filters,
     $limit: 1,
     $sort: {
       price: 1,
@@ -156,9 +155,8 @@ const fetchMinPrice = async (filters?) => {
   return results.reduce(mappings.minMaxPrice, 0)
 }
 
-const fetchMaxPrice = async (filters?) => {
+const fetchMaxPrice = async () => {
   const query = {
-    ...filters,
     $limit: 1,
     $sort: {
       price: -1,
@@ -170,8 +168,8 @@ const fetchMaxPrice = async (filters?) => {
   return results.reduce(mappings.minMaxPrice, 0)
 }
 
-export const fetchMinMaxPrice = async (filters?) => {
-  const minPrice = await fetchMinPrice(filters)
-  const maxPrice = await fetchMaxPrice(filters)
+export const fetchMinMaxPrice = async () => {
+  const minPrice = await fetchMinPrice()
+  const maxPrice = await fetchMaxPrice()
   return { minPrice, maxPrice }
 }

--- a/src/components/molecules/InfoBar.tsx
+++ b/src/components/molecules/InfoBar.tsx
@@ -1,0 +1,48 @@
+import { Button, ButtonProps, createStyles, makeStyles, Snackbar, Theme } from '@material-ui/core'
+import MuiAlert, { Color as Severity } from '@material-ui/lab/Alert'
+import React, { FC } from 'react'
+
+export interface InfoBarProps {
+    isVisible: boolean
+    text: string
+    button: ButtonProps
+    buttonText: string
+    type: Severity
+}
+
+const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        alert: {
+            alignItems: 'center',
+            display: 'flex',
+            flexDirection: 'row',
+        },
+        button: {
+            padding: 0
+        }
+    }),
+)
+
+const InfoBar: FC<InfoBarProps> = ({ isVisible, text, button, buttonText, type }) => {
+    const classes = useStyles();
+    const action = <Button {...button} />
+    return (
+        <Snackbar
+            anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+            open={isVisible}
+        >
+            <MuiAlert severity={type} className={classes.alert}>
+                {text}
+                <Button className={classes.button} color='primary' {...button}>{buttonText}</Button>
+            </MuiAlert>
+        </Snackbar>
+        // <div className={`${classes.container} ${isVisible && classes[type]}`}>
+
+        //     {/* <Fade in={isVisible}>
+        //         <Typography>{text}<Button {...button}>{buttonText}</Button></Typography>
+        //     </Fade> */}
+        // </div>
+    )
+}
+
+export default InfoBar;

--- a/src/components/molecules/InfoBar.tsx
+++ b/src/components/molecules/InfoBar.tsx
@@ -1,48 +1,44 @@
-import { Button, ButtonProps, createStyles, makeStyles, Snackbar, Theme } from '@material-ui/core'
+import {
+  Button, ButtonProps, createStyles, makeStyles, Snackbar, Theme,
+} from '@material-ui/core'
 import MuiAlert, { Color as Severity } from '@material-ui/lab/Alert'
 import React, { FC } from 'react'
 
 export interface InfoBarProps {
-    isVisible: boolean
-    text: string
-    button: ButtonProps
-    buttonText: string
-    type: Severity
+  isVisible: boolean
+  text: string
+  button: ButtonProps
+  buttonText: string
+  type: Severity
 }
 
-const useStyles = makeStyles((theme: Theme) =>
-    createStyles({
-        alert: {
-            alignItems: 'center',
-            display: 'flex',
-            flexDirection: 'row',
-        },
-        button: {
-            padding: 0
-        }
-    }),
-)
+const useStyles = makeStyles((_: Theme) => createStyles({
+  alert: {
+    alignItems: 'center',
+    display: 'flex',
+    flexDirection: 'row',
+  },
+  button: {
+    padding: 0,
+  },
+}))
 
-const InfoBar: FC<InfoBarProps> = ({ isVisible, text, button, buttonText, type }) => {
-    const classes = useStyles();
-    const action = <Button {...button} />
-    return (
-        <Snackbar
-            anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-            open={isVisible}
-        >
-            <MuiAlert severity={type} className={classes.alert}>
-                {text}
-                <Button className={classes.button} color='primary' {...button}>{buttonText}</Button>
-            </MuiAlert>
-        </Snackbar>
-        // <div className={`${classes.container} ${isVisible && classes[type]}`}>
+const InfoBar: FC<InfoBarProps> = ({
+  isVisible, text, button, buttonText, type,
+}) => {
+  const classes = useStyles()
 
-        //     {/* <Fade in={isVisible}>
-        //         <Typography>{text}<Button {...button}>{buttonText}</Button></Typography>
-        //     </Fade> */}
-        // </div>
-    )
+  return (
+    <Snackbar
+      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+      open={isVisible}
+    >
+      <MuiAlert severity={type} className={classes.alert}>
+        {text}
+        <Button className={classes.button} color="primary" {...button}>{buttonText}</Button>
+      </MuiAlert>
+    </Snackbar>
+  )
 }
 
-export default InfoBar;
+export default InfoBar

--- a/src/components/pages/rns/buy/DomainOffersCheckoutPage.tsx
+++ b/src/components/pages/rns/buy/DomainOffersCheckoutPage.tsx
@@ -127,14 +127,14 @@ const DomainOffersCheckoutPage: FC<{}> = () => {
 
   const {
     item: {
-      sellerAddress,
+      ownerAddress,
       expirationDate,
       price,
       paymentToken,
     },
     isProcessing,
   } = currentOrder
-  const isOwnDomain = account?.toLowerCase() === sellerAddress.toLowerCase()
+  const isOwnDomain = account?.toLowerCase() === ownerAddress.toLowerCase()
 
   const currency = crypto[paymentToken]
 
@@ -149,7 +149,7 @@ const DomainOffersCheckoutPage: FC<{}> = () => {
 
   const details = {
     NAME: domainName || <AddressItem pretext="Unknown RNS:" value={tokenId} />,
-    SELLER: <AddressItem value={sellerAddress} />,
+    SELLER: <AddressItem value={ownerAddress} />,
     'RENEWAL DATE': expirationDate.toLocaleDateString(),
     PRICE: PriceCell,
   }

--- a/src/components/pages/rns/buy/DomainOffersPage.tsx
+++ b/src/components/pages/rns/buy/DomainOffersPage.tsx
@@ -1,15 +1,16 @@
 import { Web3Store } from '@rsksmart/rif-ui'
-import { createOffersService, DOMAINS_SERVICE_PATHS, fetchDomainOffers } from 'api/rif-marketplace-cache/domainsController'
+import { createService } from 'api/rif-marketplace-cache/cacheController'
+import { fetchDomainOffers, RnsServicePaths } from 'api/rif-marketplace-cache/domainsController'
 import { AddressItem, CombinedPriceCell, SelectRowButton } from 'components/molecules'
 import DomainOfferFilters from 'components/organisms/filters/DomainOffersFilters'
 import MarketPageTemplate from 'components/templates/MarketPageTemplate'
 import { MarketListingTypes } from 'models/Market'
+import { DomainOffer } from 'models/marketItems/DomainItem'
 import React, { FC, useContext, useEffect } from 'react'
 import { useHistory } from 'react-router-dom'
 import ROUTES from 'routes'
 import { MARKET_ACTIONS } from 'store/Market/marketActions'
 import MarketStore, { TxType } from 'store/Market/MarketStore'
-import { DomainOffer } from 'models/marketItems/DomainItem'
 
 const LISTING_TYPE = MarketListingTypes.DOMAIN_OFFERS
 const TX_TYPE = TxType.BUY
@@ -39,7 +40,7 @@ const DomainOffersPage: FC = () => {
 
   /* Initialise */
   useEffect(() => {
-    if (servicePath && servicePath !== DOMAINS_SERVICE_PATHS.BUY()) {
+    if (servicePath && servicePath !== RnsServicePaths.BUY) {
       dispatch({
         type: MARKET_ACTIONS.TOGGLE_TX_TYPE,
         payload: {
@@ -51,7 +52,7 @@ const DomainOffersPage: FC = () => {
 
   useEffect(() => {
     if (!servicePath) {
-      const serviceAddr = createOffersService(dispatch)
+      const serviceAddr = createService(RnsServicePaths.BUY, dispatch)
       dispatch({
         type: MARKET_ACTIONS.CONNECT_SERVICE,
         payload: {
@@ -64,12 +65,11 @@ const DomainOffersPage: FC = () => {
   }, [servicePath, dispatch])
 
   useEffect(() => {
-    if (servicePath && servicePath === DOMAINS_SERVICE_PATHS.BUY()) {
+    if (servicePath && servicePath === RnsServicePaths.BUY) {
       fetchDomainOffers(offerFilters)
         .then((items) => dispatch({
           type: MARKET_ACTIONS.SET_ITEMS,
           payload: {
-            listingType: LISTING_TYPE,
             items,
           },
         }))
@@ -80,7 +80,7 @@ const DomainOffersPage: FC = () => {
 
   const headers = {
     domainName: 'Name',
-    sellerAddress: 'Seller',
+    ownerAddress: 'Owner',
     expirationDate: 'Renewal Date',
     combinedPrice: 'Price',
     action1: '',
@@ -93,7 +93,7 @@ const DomainOffersPage: FC = () => {
         price,
         domainName,
         paymentToken,
-        sellerAddress,
+        ownerAddress,
         expirationDate,
         tokenId,
       } = domainItem
@@ -103,7 +103,7 @@ const DomainOffersPage: FC = () => {
       const displayItem = {
         id,
         domainName: domainName || pseudoResolvedName || <AddressItem pretext="Unknown RNS:" value={tokenId} />,
-        sellerAddress: <AddressItem value={sellerAddress} />,
+        ownerAddress: <AddressItem value={ownerAddress} />,
         expirationDate: expirationDate.toLocaleDateString(),
         combinedPrice: <CombinedPriceCell
           price={price.toString()}
@@ -112,7 +112,7 @@ const DomainOffersPage: FC = () => {
           currencyFiat={currentFiat.displayName}
           divider=" = "
         />,
-        action1: (account?.toLowerCase() === sellerAddress.toLowerCase()) ? 'your offer' : (
+        action1: (account?.toLowerCase() === ownerAddress.toLowerCase()) ? 'your offer' : (
           <SelectRowButton
             id={id}
             handleSelect={() => {

--- a/src/components/pages/rns/buy/DomainOffersPage.tsx
+++ b/src/components/pages/rns/buy/DomainOffersPage.tsx
@@ -51,7 +51,7 @@ const DomainOffersPage: FC = () => {
 
   useEffect(() => {
     if (!servicePath) {
-      const serviceAddr = createOffersService()
+      const serviceAddr = createOffersService(dispatch)
       dispatch({
         type: MARKET_ACTIONS.CONNECT_SERVICE,
         payload: {

--- a/src/components/pages/rns/sell/MyDomainsPage.tsx
+++ b/src/components/pages/rns/sell/MyDomainsPage.tsx
@@ -63,7 +63,7 @@ const MyDomainsPage: FC<{}> = () => {
 
   useEffect(() => {
     if (!servicePath && account) {
-      const serviceAddr = createDomainService(account)
+      const serviceAddr = createDomainService(account, dispatch)
       dispatch({
         type: MARKET_ACTIONS.CONNECT_SERVICE,
         payload: {

--- a/src/components/pages/rns/sell/SoldDomainsPage.tsx
+++ b/src/components/pages/rns/sell/SoldDomainsPage.tsx
@@ -62,7 +62,7 @@ const SoldDomainsPage: FC<{}> = () => {
   }, [servicePath, account, dispatch])
   useEffect(() => {
     if (!servicePath && account) {
-      const serviceAddr = createSoldService(account)
+      const serviceAddr = createSoldService(account, dispatch)
       dispatch({
         type: MARKET_ACTIONS.CONNECT_SERVICE,
         payload: {

--- a/src/components/pages/rns/sell/SoldDomainsPage.tsx
+++ b/src/components/pages/rns/sell/SoldDomainsPage.tsx
@@ -1,15 +1,16 @@
 import { Web3Store } from '@rsksmart/rif-ui'
-import { createSoldService, DOMAINS_SERVICE_PATHS, fetchSoldDomains } from 'api/rif-marketplace-cache/domainsController'
+import { createService } from 'api/rif-marketplace-cache/cacheController'
+import { fetchSoldDomains, RnsServicePaths } from 'api/rif-marketplace-cache/domainsController'
 import { AddressItem, CombinedPriceCell } from 'components/molecules'
 import DomainFilters from 'components/organisms/filters/DomainFilters'
 import MarketPageTemplate from 'components/templates/MarketPageTemplate'
 import { MarketListingTypes } from 'models/Market'
 import { SoldDomain } from 'models/marketItems/DomainItem'
 import React, { FC, useContext, useEffect } from 'react'
-import { MARKET_ACTIONS } from 'store/Market/marketActions'
-import MarketStore, { TxType } from 'store/Market/MarketStore'
 import { useHistory } from 'react-router-dom'
 import ROUTES from 'routes'
+import { MARKET_ACTIONS } from 'store/Market/marketActions'
+import MarketStore, { TxType } from 'store/Market/MarketStore'
 
 const LISTING_TYPE = MarketListingTypes.DOMAINS
 const TX_TYPE = TxType.SOLD
@@ -51,7 +52,7 @@ const SoldDomainsPage: FC<{}> = () => {
   }, [statusFilter, dispatch, history])
 
   useEffect(() => {
-    if (servicePath && account && servicePath !== DOMAINS_SERVICE_PATHS.SOLD(account)) {
+    if (account && servicePath && servicePath !== RnsServicePaths.SOLD) {
       dispatch({
         type: MARKET_ACTIONS.TOGGLE_TX_TYPE,
         payload: {
@@ -62,7 +63,7 @@ const SoldDomainsPage: FC<{}> = () => {
   }, [servicePath, account, dispatch])
   useEffect(() => {
     if (!servicePath && account) {
-      const serviceAddr = createSoldService(account, dispatch)
+      const serviceAddr = createService(RnsServicePaths.SOLD, dispatch)
       dispatch({
         type: MARKET_ACTIONS.CONNECT_SERVICE,
         payload: {
@@ -75,12 +76,11 @@ const SoldDomainsPage: FC<{}> = () => {
   }, [servicePath, account, dispatch])
 
   useEffect(() => {
-    if (servicePath && account && servicePath === DOMAINS_SERVICE_PATHS.SOLD(account) && domainFilters.status === 'sold') { // TODO: refactor
+    if (account && servicePath === RnsServicePaths.SOLD && domainFilters.status === 'sold') { // TODO: refactor
       fetchSoldDomains(domainFilters)
         .then((items) => dispatch({
           type: MARKET_ACTIONS.SET_ITEMS,
           payload: {
-            listingType: LISTING_TYPE,
             items,
           },
         }))

--- a/src/components/templates/MarketPageTemplate.tsx
+++ b/src/components/templates/MarketPageTemplate.tsx
@@ -8,7 +8,6 @@ import { MarketItemType } from 'models/Market'
 import React, { FC, useContext, useEffect } from 'react'
 import { MARKET_ACTIONS } from 'store/Market/marketActions'
 import MarketStore from 'store/Market/MarketStore'
-import { fetchMinMaxPrice } from 'api/rif-marketplace-cache/domainsController'
 import { Grid } from '@material-ui/core'
 
 export interface MarketPageTemplateProps {
@@ -61,7 +60,7 @@ const MarketPageTemplate: FC<MarketPageTemplateProps> = ({
     dispatch,
   } = useContext(MarketStore)
 
-  const { listingType } = currentListing
+  const { listingType, txType } = currentListing
   const updatedTokensCount = metadata[listingType].updatedTokens.length
   const needsRefresh = !!updatedTokensCount
 
@@ -106,20 +105,12 @@ const MarketPageTemplate: FC<MarketPageTemplateProps> = ({
                 type="info"
                 button={{
                   onClick: () => {
-                    fetchMinMaxPrice()
-                      .then(({ minPrice, maxPrice }) => {
-                        dispatch({
-                          type: MARKET_ACTIONS.SET_FILTER,
-                          payload: {
-                            filterItems: {
-                              price: {
-                                $gte: minPrice,
-                                $lte: maxPrice,
-                              },
-                            },
-                          },
-                        })
-                      })
+                    dispatch({
+                      type: MARKET_ACTIONS.TOGGLE_TX_TYPE,
+                      payload: {
+                        txType,
+                      },
+                    })
                   },
                 }}
               />

--- a/src/components/templates/MarketPageTemplate.tsx
+++ b/src/components/templates/MarketPageTemplate.tsx
@@ -1,13 +1,13 @@
-import React, { FC, useContext, useEffect } from 'react'
+import { makeStyles, Theme } from '@material-ui/core/styles'
+import { Grid, Web3Store } from '@rsksmart/rif-ui'
+import { fetchExchangeRatesFor, tokenDisplayNames } from 'api/rif-marketplace-cache/exchangeRateController'
+import InfoBar from 'components/molecules/InfoBar'
 import MarketFilter from 'components/templates/marketplace/MarketFilter'
 import Marketplace, { TableHeaders } from 'components/templates/marketplace/Marketplace'
 import { MarketItemType } from 'models/Market'
-import { makeStyles, Theme } from '@material-ui/core/styles'
-import { Grid } from '@material-ui/core'
-import { Web3Store } from '@rsksmart/rif-ui'
-import MarketStore from 'store/Market/MarketStore'
-import { fetchExchangeRatesFor, tokenDisplayNames } from 'api/rif-marketplace-cache/exchangeRateController'
+import React, { FC, useContext, useEffect } from 'react'
 import { MARKET_ACTIONS } from 'store/Market/marketActions'
+import MarketStore from 'store/Market/MarketStore'
 
 export interface MarketPageTemplateProps {
   className: string
@@ -31,7 +31,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   filtersContainer: {
     width: '100%',
-  },
+  }
 }))
 
 const MarketPageTemplate: FC<MarketPageTemplateProps> = ({
@@ -53,9 +53,14 @@ const MarketPageTemplate: FC<MarketPageTemplateProps> = ({
           rif,
         },
       },
+      currentListing,
+      metadata
     },
     dispatch,
   } = useContext(MarketStore)
+
+  const { listingType } = currentListing;
+  const { isUpToDate } = metadata[listingType];
 
   const { rate: rifXr, displayName } = rif
   useEffect(() => {
@@ -91,6 +96,19 @@ const MarketPageTemplate: FC<MarketPageTemplateProps> = ({
               <MarketFilter>{filterItems}</MarketFilter>
             </Grid>
             <Grid className={classes.resultsContainer} item sm={12} md={9}>
+              <InfoBar isVisible={!isUpToDate}
+                text='This content had changed. Please,'
+                buttonText='refresh'
+                type='info'
+                button={{
+                  onClick: () => {
+                    dispatch({
+                      type: MARKET_ACTIONS.SET_FILTER,
+                      payload: {}
+                    })
+                  }
+                }}
+              />
               <Marketplace items={itemCollection} headers={headers} />
             </Grid>
           </>

--- a/src/models/Market.ts
+++ b/src/models/Market.ts
@@ -1,5 +1,5 @@
-import { DomainOffersFilter, DomainFilter } from 'api/models/RnsFilter'
-import { DomainOffer, Domain } from './marketItems/DomainItem'
+import { RnsFilterType } from 'api/models/RnsFilter'
+import { RnsItemType } from './marketItems/DomainItem'
 import { StorageItemIface } from './marketItems/StorageItem'
 
 export interface MarketItemIface {
@@ -12,7 +12,7 @@ export enum MarketListingTypes {
     STORAGE = 'storage',
 }
 
-export type MarketItemType = Domain & DomainOffer & StorageItemIface
+export type MarketItemType = RnsItemType & StorageItemIface
 
 
 export interface MarketFilter {
@@ -21,4 +21,4 @@ export interface MarketFilter {
     } | any | undefined
 }
 
-export type MarketFilterType = DomainFilter & DomainOffersFilter
+export type MarketFilterType = RnsFilterType

--- a/src/models/marketItems/DomainItem.ts
+++ b/src/models/marketItems/DomainItem.ts
@@ -6,7 +6,7 @@ export interface DomainOffer extends MarketItemIface {
     domainName: string
     expirationDate: Date
     price: number
-    sellerAddress: string
+    ownerAddress: string
 }
 
 export interface Domain extends MarketItemIface {
@@ -25,3 +25,5 @@ export interface SoldDomain extends MarketItemIface {
     domainName: string
     buyer: string
 }
+
+export type RnsItemType = Domain & DomainOffer & SoldDomain

--- a/src/store/Market/MarketStore.tsx
+++ b/src/store/Market/MarketStore.tsx
@@ -64,6 +64,7 @@ interface MarketStorePropsType {
 export const initialState: MarketStateType = {
   filters: {
     domains: {
+      ownerAddress: '',
       status: 'owned',
     },
     domainOffers: {

--- a/src/store/Market/MarketStore.tsx
+++ b/src/store/Market/MarketStore.tsx
@@ -5,8 +5,8 @@ import { MarketAction } from './marketActions'
 import marketReducer from './marketReducer'
 
 export enum TxType {
-  SELL = 1,
   BUY = 0,
+  SELL = 1,
   SOLD = 2,
 }
 export interface CurrentOrderType {
@@ -29,13 +29,16 @@ export interface MarketStateType {
   }
   metadata: {
     domains: {
-      lastUpdated: number
+      lastUpdated: number,
+      isUpToDate?: Boolean
     }
     domainOffers: {
-      lastUpdated: number
+      lastUpdated: number,
+      isUpToDate?: Boolean
     }
     storage: {
-      lastUpdated: number
+      lastUpdated: number,
+      isUpToDate?: Boolean
     }
   }
   currentOrder?: CurrentOrderType

--- a/src/store/Market/MarketStore.tsx
+++ b/src/store/Market/MarketStore.tsx
@@ -29,16 +29,16 @@ export interface MarketStateType {
   }
   metadata: {
     domains: {
-      lastUpdated: number,
-      isUpToDate?: Boolean
+      lastUpdated: number
+      updatedTokens: []
     }
     domainOffers: {
-      lastUpdated: number,
-      isUpToDate?: Boolean
+      lastUpdated: number
+      updatedTokens: []
     }
     storage: {
-      lastUpdated: number,
-      isUpToDate?: Boolean
+      lastUpdated: number
+      updatedTokens: []
     }
   }
   currentOrder?: CurrentOrderType
@@ -76,12 +76,15 @@ export const initialState: MarketStateType = {
   metadata: {
     domains: {
       lastUpdated: -1,
+      updatedTokens: [],
     },
     domainOffers: {
       lastUpdated: -1,
+      updatedTokens: [],
     },
     storage: {
       lastUpdated: -1,
+      updatedTokens: [],
     },
   },
   exchangeRates: {

--- a/src/store/Market/marketActions.ts
+++ b/src/store/Market/marketActions.ts
@@ -24,7 +24,6 @@ export interface ItemPayload {
 }
 
 export interface ListingPayload {
-  listingType: MarketListingTypes
   items: MarketItemType[]
 }
 

--- a/src/store/Market/marketActions.ts
+++ b/src/store/Market/marketActions.ts
@@ -13,7 +13,7 @@ export enum MARKET_ACTIONS {
   CONNECT_SERVICE = 'CONNECT_SERVICE',
   SET_EXCHANGE_RATE = 'SET_EXCHANGE_RATE',
   CLEAN_UP = 'CLEAN_UP',
-  SET_META = "SET_META"
+  SET_META = 'SET_META'
 }
 
 export interface ItemPayload {
@@ -36,6 +36,7 @@ export interface ConnectionPayload {
   servicePath: string
   listingType: MarketListingTypes
   txType: TxType
+  items: MarketItemType[]
 }
 
 export interface ExchangeRatePayload {
@@ -46,7 +47,7 @@ export interface ExchangeRatePayload {
 }
 
 export interface MetadataPayload {
-  isUpToDate?: Boolean
+  updatedTokenId: string
 }
 
 export interface TxTypeChangePayload {

--- a/src/store/Market/marketActions.ts
+++ b/src/store/Market/marketActions.ts
@@ -12,7 +12,8 @@ export enum MARKET_ACTIONS {
   TOGGLE_TX_TYPE = 'TOGGLE_TX_TYPE',
   CONNECT_SERVICE = 'CONNECT_SERVICE',
   SET_EXCHANGE_RATE = 'SET_EXCHANGE_RATE',
-  CLEAN_UP = 'CLEAN_UP'
+  CLEAN_UP = 'CLEAN_UP',
+  SET_META = "SET_META"
 }
 
 export interface ItemPayload {
@@ -44,11 +45,15 @@ export interface ExchangeRatePayload {
   }
 }
 
+export interface MetadataPayload {
+  isUpToDate?: Boolean
+}
+
 export interface TxTypeChangePayload {
   txType: TxType
 }
 
-export type MarketPayloadType = ItemPayload & FilterPayload & ConnectionPayload & TxTypeChangePayload & ExchangeRatePayload & ListingPayload
+export type MarketPayloadType = ItemPayload & FilterPayload & ConnectionPayload & TxTypeChangePayload & ExchangeRatePayload & ListingPayload & MetadataPayload
 
 export interface MarketAction extends ActionType<MarketPayloadType> {
   type: MARKET_ACTIONS

--- a/src/store/Market/marketReducer.ts
+++ b/src/store/Market/marketReducer.ts
@@ -31,16 +31,13 @@ const {
 const marketActions: MarketActionsType = {
   [NOOP]: (state: MarketStateType, _: MarketPayloadType) => state,
   [SET_ITEMS]: (state: MarketStateType, payload: ListingPayload) => {
-    const { listingType } = payload
     const { currentListing, metadata } = state
+    const listingType = currentListing?.listingType
 
     if (!currentListing) return state
 
-    if (listingType !== currentListing.listingType) {
-      logger.error('There is a mismatch of listing types in the current items (market store)!')
-      logger.error(`Expected: ${currentListing.listingType}`)
-      logger.error(`Got: ${listingType}`)
-    }
+    if (!listingType) return state
+
     const newState = {
       ...state,
       currentListing: {
@@ -125,13 +122,21 @@ const marketActions: MarketActionsType = {
     const { currentListing, metadata } = state
     const listingType = currentListing?.listingType as string
 
+    if (!(currentListing && listingType)) return state
+
+    const updateTokens = [
+      ...metadata[listingType].updatedTokens,
+      ...[payload.updatedTokenId],
+    ]
+    const tokensSet: Set<string> = new Set(updateTokens)
+
     return listingType ? {
       ...state,
       metadata: {
         ...metadata,
         [listingType]: {
           ...metadata[listingType],
-          updatedTokens: [...metadata[listingType].updatedTokens, ...[payload.updatedTokenId]],
+          updatedTokens: Array.from(tokensSet),
         },
       },
     } : state

--- a/src/store/Market/marketReducer.ts
+++ b/src/store/Market/marketReducer.ts
@@ -52,7 +52,7 @@ const marketActions: MarketActionsType = {
         [listingType]: {
           ...metadata[listingType],
           lastUpdated: Date.now(),
-          isUpToDate: true,
+          updatedTokens: [],
         },
       },
     }
@@ -122,20 +122,20 @@ const marketActions: MarketActionsType = {
     currentOrder: undefined,
   }),
   [SET_META]: (state: MarketStateType, payload: MetadataPayload) => {
-    const { currentListing, metadata } = state;
-    const listingType = currentListing?.listingType as string;
+    const { currentListing, metadata } = state
+    const listingType = currentListing?.listingType as string
 
-    return {
+    return listingType ? {
       ...state,
       metadata: {
         ...metadata,
         [listingType]: {
           ...metadata[listingType],
-          ...payload,
+          updatedTokens: [...metadata[listingType].updatedTokens, ...[payload.updatedTokenId]],
         },
       },
-    }
-  }
+    } : state
+  },
 }
 
 


### PR DESCRIPTION
This PR adds a package @material-ui/lab to allow us to use their Alert and later Pagination components.
This means that you must `npm i` after checking out this PR.
Closes #51 
To test this you will need [Cache PR#130](https://github.com/rsksmart/rif-marketplace-cache/pull/130)