### PR TITLE
fix: close modal on HOC WithAccount once the provider is set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2272,8 +2272,9 @@
       }
     },
     "@rsksmart/rif-ui": {
-      "version": "github:rsksmart/rif-ui#0c1af8b220fb800f9cb6087691897b8575158542",
-      "from": "github:rsksmart/rif-ui#hotfix/accountModalCloses"
+      "version": "0.1.0-dev.3",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rif-ui/-/rif-ui-0.1.0-dev.3.tgz",
+      "integrity": "sha512-L3tjZeSx5aDinQ9vEjLLGmau1cMgb1dsi+y/ivJGtvD031xcPHjYTnD5tHTJosvk5KS5VU63UaZ4/0Kqc/RkdQ=="
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2272,9 +2272,8 @@
       }
     },
     "@rsksmart/rif-ui": {
-      "version": "0.1.0-dev.2",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rif-ui/-/rif-ui-0.1.0-dev.2.tgz",
-      "integrity": "sha512-G9DnuJ7SYWFQzigPXyORPH4ykMU+4fzAofejmVbZaBM3MDLZ6GeIkAZyNQ3+EMn90rSx/AptZqIfq76vGOuSCA=="
+      "version": "github:rsksmart/rif-ui#0c1af8b220fb800f9cb6087691897b8575158542",
+      "from": "github:rsksmart/rif-ui#hotfix/accountModalCloses"
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@rsksmart/erc677": "^1.0.2",
     "@rsksmart/erc721": "^1.0.0",
     "@rsksmart/rif-marketplace-nfts": "0.0.2",
-    "@rsksmart/rif-ui": "github:rsksmart/rif-ui#hotfix/accountModalCloses",
+    "@rsksmart/rif-ui": "0.1.0-dev.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@rsksmart/erc677": "^1.0.2",
     "@rsksmart/erc721": "^1.0.0",
     "@rsksmart/rif-marketplace-nfts": "0.0.2",
-    "@rsksmart/rif-ui": "^0.1.0-dev.2",
+    "@rsksmart/rif-ui": "github:rsksmart/rif-ui#hotfix/accountModalCloses",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",

--- a/src/components/hoc/WithAccount.tsx
+++ b/src/components/hoc/WithAccount.tsx
@@ -21,7 +21,6 @@ const WithAccount = ({ WrappedComponent, onChange }) => {
     if (userAccount) {
       onChange()
     }
-    setModalOpened(false)
   }
 
   return (

--- a/src/components/hoc/WithAccount.tsx
+++ b/src/components/hoc/WithAccount.tsx
@@ -21,6 +21,7 @@ const WithAccount = ({ WrappedComponent, onChange }) => {
     if (userAccount) {
       onChange()
     }
+    setModalOpened(false)
   }
 
   return (


### PR DESCRIPTION
This PR closes #169.

~### Warning
Before merging, [this rif-ui PR](https://github.com/rsksmart/rif-ui/pull/63) needs to be merged and included in a new `npm` version. We could then update the `package.json` dependency~