### PR TITLE
feat: add link to RNS Manager

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,0 @@
-{
-    "printWidth": 80,
-    "singleQuote": true,
-    "trailingComma": "all"
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3404,9 +3404,9 @@
       }
     },
     "@testing-library/user-event": {
-      "version": "11.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-11.4.1.tgz",
-      "integrity": "sha512-ZaK+3AmocU2WjJ7UyrlnmdPecYt4fridqMwrniENCqoy/Pj2Nc9tTnpjCvMN/Ql/DQ0eRqfBoZdKNqYPBMZFhA==",
+      "version": "12.0.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.0.6.tgz",
+      "integrity": "sha512-rPAlp3dCdn2kfc8qxDOdi00/4pcbfeQigCMiew0SnwbfpgbVLKwhVicjEt9Lt8eR4klbhToTZ3AVi7r10qAbNg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.10.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3501,9 +3501,9 @@
       }
     },
     "@types/jest": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-      "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.0.tgz",
+      "integrity": "sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2223,15 +2223,27 @@
       }
     },
     "@material-ui/lab": {
-      "version": "4.0.0-alpha.55",
-      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.55.tgz",
-      "integrity": "sha512-mPHiS52Z1AT6NlWNp07xxTkoKGU3DZhoGdVtLKGy2+uMH5t4/UPtiZLRab7hR3hvuHvguxgV4tkBC9ww3xqUzA==",
+      "version": "4.0.0-alpha.56",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.56.tgz",
+      "integrity": "sha512-xPlkK+z/6y/24ka4gVJgwPfoCF4RCh8dXb1BNE7MtF9bXEBLN/lBxNTK8VAa0qm3V2oinA6xtUIdcRh0aeRtVw==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/utils": "^4.9.6",
+        "@material-ui/utils": "^4.10.2",
         "clsx": "^1.0.4",
         "prop-types": "^15.7.2",
         "react-is": "^16.8.0"
+      },
+      "dependencies": {
+        "@material-ui/utils": {
+          "version": "4.10.2",
+          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.10.2.tgz",
+          "integrity": "sha512-eg29v74P7W5r6a4tWWDAAfZldXIzfyO1am2fIsC39hdUUHm/33k6pGOKPbgDjg/U/4ifmgAePy/1OjkKN6rFRw==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.8.0"
+          }
+        }
       }
     },
     "@material-ui/styles": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27786,6 +27786,11 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
       "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ=="
     },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3250,13 +3250,13 @@
       }
     },
     "@testing-library/jest-dom": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.9.0.tgz",
-      "integrity": "sha512-uZ68dyILuM2VL13lGz4ehFEAgxzvLKRu8wQxyAZfejWnyMhmipJ60w4eG81NQikJHBfaYXx+Or8EaPQTDwGfPA==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.10.1.tgz",
+      "integrity": "sha512-uv9lLAnEFRzwUTN/y9lVVXVXlEzazDkelJtM5u92PsGkEasmdI+sfzhZHxSDzlhZVTrlLfuMh2safMr8YmzXLg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2",
-        "@types/testing-library__jest-dom": "^5.0.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
         "chalk": "^3.0.0",
         "css": "^2.2.4",
         "css.escape": "^1.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3713,9 +3713,9 @@
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
     "@types/react": {
-      "version": "16.9.35",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.35.tgz",
-      "integrity": "sha512-q0n0SsWcGc8nDqH2GJfWQWUOmZSJhXV64CjVN5SvcNti3TdEaA3AH0D8DwNmMdzjMAC/78tB8nAZIlV8yTz+zQ==",
+      "version": "16.9.38",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.38.tgz",
+      "integrity": "sha512-pHAeZbjjNRa/hxyNuLrvbxhhnKyKNiLC6I5fRF2Zr/t/S6zS41MiyzH4+c+1I9vVfvuRt1VS2Lodjr4ZWnxrdA==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2989,9 +2989,9 @@
       }
     },
     "@rsksmart/rif-ui": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rif-ui/-/rif-ui-0.1.1.tgz",
-      "integrity": "sha512-5y19VxLCj08KqEtgZ7l+DhzkU1LjoUqhcL8/elJP9cU+cQRsnRclm85wv88CioDRkULz8lz1lAOW582sXLRxyA=="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rif-ui/-/rif-ui-0.1.2.tgz",
+      "integrity": "sha512-gYSoj0D41ffn2QTDG/P/hAtkUS8A1ysxNqYAinO1V1Fh3eb4x7T5Vd1QnTdoa58hzKHRf9/tKhPTEp2lCeVmKA=="
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4434,12 +4434,13 @@
       "dev": true
     },
     "aria-query": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
-      "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "dev": true,
       "requires": {
-        "ast-types-flow": "0.0.7",
-        "commander": "^2.11.0"
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
       }
     },
     "arity-n": {
@@ -4663,6 +4664,12 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
     },
+    "axe-core": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
+      "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
+      "dev": true
+    },
     "axios": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
@@ -4699,9 +4706,9 @@
       }
     },
     "axobject-query": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.2.tgz",
-      "integrity": "sha512-ICt34ZmrVt8UQnvPl6TVyDTkmhXmAyAT4Jh5ugfGUX4MOrZ+U/ZY6/sdylRw3qGNr9Ub5AJsaHeDMzNLehRdOQ=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
+      "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA=="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -11438,25 +11445,39 @@
       }
     },
     "eslint-plugin-jsx-a11y": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
-      "integrity": "sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.3.1.tgz",
+      "integrity": "sha512-i1S+P+c3HOlBJzMFORRbC58tHa65Kbo8b52/TwCwSKLohwvpfT5rm2GjGWzOHTEuq4xxf2aRlHHTtmExDQOP+g==",
+      "dev": true,
       "requires": {
-        "@babel/runtime": "^7.4.5",
-        "aria-query": "^3.0.0",
-        "array-includes": "^3.0.3",
+        "@babel/runtime": "^7.10.2",
+        "aria-query": "^4.2.2",
+        "array-includes": "^3.1.1",
         "ast-types-flow": "^0.0.7",
-        "axobject-query": "^2.0.2",
-        "damerau-levenshtein": "^1.0.4",
-        "emoji-regex": "^7.0.2",
+        "axe-core": "^3.5.4",
+        "axobject-query": "^2.1.2",
+        "damerau-levenshtein": "^1.0.6",
+        "emoji-regex": "^9.0.0",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^2.2.1"
+        "jsx-ast-utils": "^2.4.1",
+        "language-tags": "^1.0.5"
       },
       "dependencies": {
         "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.0.0.tgz",
+          "integrity": "sha512-6p1NII1Vm62wni/VR/cUMauVQoxmLVb9csqQlvLz+hO2gk8U2UYDfXHQSUYIBKmZwAKz867IDqG7B+u0mj+M6w==",
+          "dev": true
+        },
+        "jsx-ast-utils": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
+          "integrity": "sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==",
+          "dev": true,
+          "requires": {
+            "array-includes": "^3.1.1",
+            "object.assign": "^4.1.0"
+          }
         }
       }
     },
@@ -17029,6 +17050,21 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
+    },
+    "language-subtag-registry": {
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.20.tgz",
+      "integrity": "sha512-KPMwROklF4tEx283Xw0pNKtfTj1gZ4UByp4EsIFWLgBavJltF4TiYPc39k06zSTsLzxTVXXDSpbwaQXaFB4Qeg==",
+      "dev": true
+    },
+    "language-tags": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
+      "integrity": "sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=",
+      "dev": true,
+      "requires": {
+        "language-subtag-registry": "~0.3.2"
+      }
     },
     "last-call-webpack-plugin": {
       "version": "3.0.0",
@@ -22607,6 +22643,15 @@
         "workbox-webpack-plugin": "4.3.1"
       },
       "dependencies": {
+        "aria-query": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+          "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+          "requires": {
+            "ast-types-flow": "0.0.7",
+            "commander": "^2.11.0"
+          }
+        },
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -22629,6 +22674,11 @@
             "isarray": "^1.0.0"
           }
         },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+        },
         "eslint-plugin-import": {
           "version": "2.20.1",
           "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.1.tgz",
@@ -22646,6 +22696,22 @@
             "object.values": "^1.1.0",
             "read-pkg-up": "^2.0.0",
             "resolve": "^1.12.0"
+          }
+        },
+        "eslint-plugin-jsx-a11y": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
+          "integrity": "sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==",
+          "requires": {
+            "@babel/runtime": "^7.4.5",
+            "aria-query": "^3.0.0",
+            "array-includes": "^3.0.3",
+            "ast-types-flow": "^0.0.7",
+            "axobject-query": "^2.0.2",
+            "damerau-levenshtein": "^1.0.4",
+            "emoji-regex": "^7.0.2",
+            "has": "^1.0.3",
+            "jsx-ast-utils": "^2.2.1"
           }
         },
         "eslint-plugin-react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2184,15 +2184,15 @@
       }
     },
     "@material-ui/core": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.10.1.tgz",
-      "integrity": "sha512-bJb/07JFTht0oSjoWMu0j7r1mx4EbJ2ZHx+OKiY+i6IYW/4JPZ1J6rZuFS2b9jT+slSONPZaZq/kHitbE5lcig==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.10.2.tgz",
+      "integrity": "sha512-Uf4iDLi9sW6HKbVQDyDZDr1nMR4RUAE7w/RIIJZGNVZResC0xwmpLRZMtaUdSO43N0R0yJehfxTi4Z461Cd49A==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@material-ui/styles": "^4.10.0",
         "@material-ui/system": "^4.9.14",
         "@material-ui/types": "^5.1.0",
-        "@material-ui/utils": "^4.9.12",
+        "@material-ui/utils": "^4.10.2",
         "@types/react-transition-group": "^4.2.0",
         "clsx": "^1.0.4",
         "hoist-non-react-statics": "^3.3.2",
@@ -2200,6 +2200,18 @@
         "prop-types": "^15.7.2",
         "react-is": "^16.8.0",
         "react-transition-group": "^4.4.0"
+      },
+      "dependencies": {
+        "@material-ui/utils": {
+          "version": "4.10.2",
+          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.10.2.tgz",
+          "integrity": "sha512-eg29v74P7W5r6a4tWWDAAfZldXIzfyO1am2fIsC39hdUUHm/33k6pGOKPbgDjg/U/4ifmgAePy/1OjkKN6rFRw==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.8.0"
+          }
+        }
       }
     },
     "@material-ui/icons": {
@@ -3692,7 +3704,6 @@
       "version": "16.9.35",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.35.tgz",
       "integrity": "sha512-q0n0SsWcGc8nDqH2GJfWQWUOmZSJhXV64CjVN5SvcNti3TdEaA3AH0D8DwNmMdzjMAC/78tB8nAZIlV8yTz+zQ==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -3734,17 +3745,6 @@
       "integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
       "requires": {
         "@types/react": "*"
-      },
-      "dependencies": {
-        "@types/react": {
-          "version": "16.9.36",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.36.tgz",
-          "integrity": "sha512-mGgUb/Rk/vGx4NCvquRuSH0GHBQKb1OqpGS9cT9lFxlTLHZgkksgI60TuIxubmn7JuCb+sENHhQciqa0npm0AQ==",
-          "requires": {
-            "@types/prop-types": "*",
-            "csstype": "^2.2.0"
-          }
-        }
       }
     },
     "@types/resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2989,9 +2989,9 @@
       }
     },
     "@rsksmart/rif-ui": {
-      "version": "0.1.0-dev.4",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rif-ui/-/rif-ui-0.1.0-dev.4.tgz",
-      "integrity": "sha512-KeLzmKDRJCgH0IH+ND9kX52zpJcq3rU/OInI3n/vng8y/9h+eOsP8fhbDL4H+mrgHAP8L6NNmUWdw3drOjjDNg=="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rif-ui/-/rif-ui-0.1.1.tgz",
+      "integrity": "sha512-5y19VxLCj08KqEtgZ7l+DhzkU1LjoUqhcL8/elJP9cU+cQRsnRclm85wv88CioDRkULz8lz1lAOW582sXLRxyA=="
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3113,9 +3113,9 @@
       }
     },
     "@testing-library/dom": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.11.0.tgz",
-      "integrity": "sha512-2j+zfA6dwnzozReA2XrbZs3e9DD9UdetONrWmumIY2QdGH0h08hRW+SaLE8kIytM6KPO5yzypHZhK5AZNFEtiw==",
+      "version": "7.16.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.16.2.tgz",
+      "integrity": "sha512-4fT5l5L+5gfNhUZVCg0wnSszbRJ7A1ZHEz32v7OzH3mcY5lUsK++brI3IB2L9F5zO4kSDc2TRGEVa8v2hgl9vA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.10.2",
@@ -3162,13 +3162,13 @@
           }
         },
         "aria-query": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.0.2.tgz",
-          "integrity": "sha512-S1G1V790fTaigUSM/Gd0NngzEfiMy9uTUfMyHhKhVyy4cH5O/eTuR01ydhGL0z4Za1PXFTRGH3qL8VhUQuEO5w==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+          "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
           "dev": true,
           "requires": {
-            "@babel/runtime": "^7.7.4",
-            "@babel/runtime-corejs3": "^7.7.4"
+            "@babel/runtime": "^7.10.2",
+            "@babel/runtime-corejs3": "^7.10.2"
           }
         },
         "chalk": {
@@ -3370,13 +3370,13 @@
       }
     },
     "@testing-library/react": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-10.2.1.tgz",
-      "integrity": "sha512-pv2jZhiZgN1/alz1aImhSasZAOPg3er2Kgcfg9fzuw7aKPLxVengqqR1n0CJANeErR1DqORauQaod+gGUgAJOQ==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-10.3.0.tgz",
+      "integrity": "sha512-Rhn5uJK6lYHWzlGVbK6uAvheAW8AUoFYxTLGdDxgsJDaK/PYy5drWfW/6YpMMOKMw+u6jHHl4MNHlt5qLHnm0Q==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.10.2",
-        "@testing-library/dom": "^7.9.0"
+        "@testing-library/dom": "^7.14.2"
       }
     },
     "@testing-library/user-event": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.9.0",
-    "@testing-library/react": "^10.2.1",
+    "@testing-library/react": "^10.3.0",
     "@testing-library/user-event": "^11.3.1",
     "@typechain/web3-v1": "^1.0.0",
     "@types/jest": "25.2.3",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "web3-utils": "^1.2.8"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^5.9.0",
+    "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^10.3.0",
     "@testing-library/user-event": "^11.3.1",
     "@typechain/web3-v1": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@typechain/web3-v1": "^1.0.0",
     "@types/jest": "26.0.0",
     "@types/node": "^14.0.13",
-    "@types/react": "16.9.35",
+    "@types/react": "16.9.38",
     "@types/react-dom": "^16.9.8",
     "@types/react-router-dom": "^5.1.5",
     "eslint-config-airbnb": "^18.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@rsksmart/erc677": "^1.0.2",
     "@rsksmart/erc721": "^1.0.0",
     "@rsksmart/rif-marketplace-nfts": "0.1.0",
-    "@rsksmart/rif-ui": "0.1.1",
+    "@rsksmart/rif-ui": "0.1.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rif-marketplace-ui",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "RIF Marketplace provides a digital catalogue with a wide range of decentralised services.",
   "keywords": [
     "RIF",
@@ -8,7 +8,7 @@
     "decentralized",
     "RSK"
   ],
-  "homepage": ".",
+  "homepage": "/",
   "bugs": {
     "url": "https://github.com/rsksmart/rif-marketplace-ui/issues/"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rif-marketplace-ui",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "RIF Marketplace provides a digital catalogue with a wide range of decentralised services.",
   "keywords": [
     "RIF",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@feathersjs/socketio-client": "^4.5.4",
     "@material-ui/core": "^4.10.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "^4.0.0-alpha.54",
+    "@material-ui/lab": "^4.0.0-alpha.56",
     "@rsksmart/erc677": "^1.0.2",
     "@rsksmart/erc721": "^1.0.0",
     "@rsksmart/rif-marketplace-nfts": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@feathersjs/feathers": "^4.5.3",
     "@feathersjs/socketio-client": "^4.5.4",
-    "@material-ui/core": "^4.10.1",
+    "@material-ui/core": "^4.10.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.54",
     "@rsksmart/erc677": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-scripts": "3.4.1",
     "socket.io-client": "^2.3.0",
     "typescript": "^3.9.5",
+    "valid-url": "^1.0.9",
     "web3": "^1.2.8",
     "web3-eth-contract": "^1.2.8",
     "web3-utils": "^1.2.8"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/react-router-dom": "^5.1.5",
     "eslint-config-airbnb": "^18.1.0",
     "eslint-plugin-import": "^2.21.1",
-    "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.20.0",
     "tasegir": "^1.7.1",
     "typechain": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^10.3.0",
-    "@testing-library/user-event": "^11.3.1",
+    "@testing-library/user-event": "^12.0.6",
     "@typechain/web3-v1": "^1.0.0",
     "@types/jest": "26.0.0",
     "@types/node": "^14.0.13",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@rsksmart/erc677": "^1.0.2",
     "@rsksmart/erc721": "^1.0.0",
     "@rsksmart/rif-marketplace-nfts": "0.1.0",
-    "@rsksmart/rif-ui": "0.1.0-dev.4",
+    "@rsksmart/rif-ui": "0.1.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@testing-library/react": "^10.3.0",
     "@testing-library/user-event": "^11.3.1",
     "@typechain/web3-v1": "^1.0.0",
-    "@types/jest": "25.2.3",
+    "@types/jest": "26.0.0",
     "@types/node": "^14.0.13",
     "@types/react": "16.9.35",
     "@types/react-dom": "^16.9.8",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,16 @@
-import React, { useState } from 'react'
-import { BrowserRouter as Router } from 'react-router-dom'
-import { ThemeProvider, makeStyles } from '@material-ui/core/styles'
-import { theme, Web3Provider, PageTemplate } from '@rsksmart/rif-ui'
-import { AppStoreProvider } from 'store/App/AppStore'
-import { MarketStoreProvider } from 'store/Market/MarketStore'
+import Collapse from '@material-ui/core/Collapse'
+import { makeStyles, ThemeProvider } from '@material-ui/core/styles'
+import Alert from '@material-ui/lab/Alert'
+import { PageTemplate, theme, Web3Provider } from '@rsksmart/rif-ui'
+import '@rsksmart/rif-ui/dist/index.css'
 import Footer from 'components/organisms/Footer'
 import Header from 'components/organisms/Header'
 import Routes from 'components/Routes'
-import '@rsksmart/rif-ui/dist/index.css'
-import Collapse from '@material-ui/core/Collapse'
-import Alert from '@material-ui/lab/Alert'
+import React, { useState } from 'react'
+import { BrowserRouter as Router } from 'react-router-dom'
+import { AppStoreProvider } from 'store/App/AppStore'
+import { BlockchainStoreProvider } from 'store/Blockchain/BlockchainStore'
+import { MarketStoreProvider } from 'store/Market/MarketStore'
 
 const requiredNetworkId: number = Number(process.env.REACT_APP_REQUIRED_NETWORK_ID) || 8545
 
@@ -40,32 +41,34 @@ const App = () => {
 
   return (
     <ThemeProvider theme={theme}>
-      <AppStoreProvider>
-        <MarketStoreProvider>
-          <Web3Provider.Provider
-            requiredNetworkId={requiredNetworkId}
-            actions={{
-              onConnectedAccountChange,
-              onConnectedNetworkChange,
-            }}
-          >
-            <Router>
-              <div className={classes.router}>
-                <Header />
-                <PageTemplate>
-                  <Collapse in={displayAlert}>
-                    <Alert severity="warning" onClose={() => setDisplayAlert(false)}>
-                      {alertMessage}
-                    </Alert>
-                  </Collapse>
-                  <Routes />
-                </PageTemplate>
-                <Footer />
-              </div>
-            </Router>
-          </Web3Provider.Provider>
-        </MarketStoreProvider>
-      </AppStoreProvider>
+      <Web3Provider.Provider
+        requiredNetworkId={requiredNetworkId}
+        actions={{
+          onConnectedAccountChange,
+          onConnectedNetworkChange,
+        }}
+      >
+        <AppStoreProvider>
+          <BlockchainStoreProvider>
+            <MarketStoreProvider>
+              <Router>
+                <div className={classes.router}>
+                  <Header />
+                  <PageTemplate>
+                    <Collapse in={displayAlert}>
+                      <Alert severity="warning" onClose={() => setDisplayAlert(false)}>
+                        {alertMessage}
+                      </Alert>
+                    </Collapse>
+                    <Routes />
+                  </PageTemplate>
+                  <Footer />
+                </div>
+              </Router>
+            </MarketStoreProvider>
+          </BlockchainStoreProvider>
+        </AppStoreProvider>
+      </Web3Provider.Provider>
     </ThemeProvider>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import '@rsksmart/rif-ui/dist/index.css'
 import Collapse from '@material-ui/core/Collapse'
 import Alert from '@material-ui/lab/Alert'
 
-const requiredNetworkId = process.env.REACT_APP_REQUIRED_NETWORK_ID || 8545
+const requiredNetworkId: number = Number(process.env.REACT_APP_REQUIRED_NETWORK_ID) || 8545
 
 const useStyles = makeStyles(() => ({
   router: {

--- a/src/api/rif-marketplace-cache/config.ts
+++ b/src/api/rif-marketplace-cache/config.ts
@@ -1,0 +1,11 @@
+import feathers from '@feathersjs/feathers'
+import socketio from '@feathersjs/socketio-client'
+import io from 'socket.io-client'
+
+const CACHE_BASE_ADDR = process.env.REACT_APP_CACHE_ADDR || 'http://localhost:3030'
+
+const socket = io(CACHE_BASE_ADDR)
+const client = feathers()
+client.configure(socketio(socket))
+
+export default client

--- a/src/api/rif-marketplace-cache/confirmationsController.ts
+++ b/src/api/rif-marketplace-cache/confirmationsController.ts
@@ -1,0 +1,59 @@
+import { Application, Service } from '@feathersjs/feathers'
+import { APIController, ServiceEventListener } from 'store/App/AppStore'
+
+type Modify<T, R> = Omit<T, keyof R> & R;
+
+export type ConfirmationAPI = APIController
+
+export interface ConfirmationsItem {
+  currentCount: number
+  targetCount: number
+}
+
+export type Confirmations = Record<string, ConfirmationsItem>
+
+interface ConfirmationsTransportItem {
+  transactionHash: string
+  confirmations: number
+  targetConfirmation: number
+  event: string
+}
+
+/* eslint-disable no-param-reassign */
+export const mapFromTransport = (data: ConfirmationsTransportItem[]): Confirmations => data.reduce((map, item: ConfirmationsTransportItem) => {
+  map[item.transactionHash] = {
+    currentCount: item.confirmations,
+    targetCount: item.targetConfirmation,
+  }
+  return map
+}, {})
+/* eslint-enable no-param-reassign */
+
+export class ConfirmationsController implements ConfirmationAPI {
+  path = '/confirmations'
+
+  service!: Service<any>
+
+  connect = (client: Application<any>) => {
+    try {
+      this.service = client.service(this.path)
+      return this.path
+    } catch (e) {
+      return undefined
+    }
+  }
+
+  fetch = async (): Promise<Confirmations> => {
+    if (!this.service) throw Error('The confirmations service is not connected')
+
+    const data = await this.service.find()
+
+    return mapFromTransport(data)
+  }
+
+  attachEvent = (name: string, callback: ServiceEventListener) => {
+    if (this.service) this.service.on(name, callback)
+  }
+
+  detachEvent = (name: string) => name
+}

--- a/src/components/atoms/Login.tsx
+++ b/src/components/atoms/Login.tsx
@@ -10,7 +10,7 @@ const Login = () => {
 
   return (
     <Web3Provider.Consumer>
-      {({ state: { web3, account, networkInfo }, actions: { setProvider } }) => (
+      {({ state: { web3, account, networkInfo }, actions: { setProvider }, availableProviders }) => (
         <Account
           web3={web3}
           account={account}
@@ -27,6 +27,7 @@ const Login = () => {
               ? `${noNetworkMessage} Please, connect to ${requiredNetworkName}.`
               : noNetworkMessage
           }
+          availableProviders={availableProviders}
         />
       )}
     </Web3Provider.Consumer>

--- a/src/components/atoms/Login.tsx
+++ b/src/components/atoms/Login.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Account, Web3Provider } from '@rsksmart/rif-ui'
 
-const requiredNetworkId = process.env.REACT_APP_REQUIRED_NETWORK_ID || 8545
+const requiredNetworkId: number = Number(process.env.REACT_APP_REQUIRED_NETWORK_ID) || 8545
 const requiredNetworkName = process.env.REACT_APP_REQUIRED_NETWORK_NAME
 
 const Login = () => {
@@ -27,7 +27,6 @@ const Login = () => {
               ? `${noNetworkMessage} Please, connect to ${requiredNetworkName}.`
               : noNetworkMessage
           }
-
         />
       )}
     </Web3Provider.Consumer>

--- a/src/components/atoms/LoginModal.tsx
+++ b/src/components/atoms/LoginModal.tsx
@@ -4,22 +4,32 @@ import { AccountModal, Web3Provider } from '@rsksmart/rif-ui'
 export interface LoginModalProps {
   open: boolean
   onProviderSet?: (account: string) => void
+  handleOnClose: () => void
 }
 
 const LoginModal: FC<LoginModalProps> = ({
   open,
   onProviderSet,
+  handleOnClose,
 }) => (
   <Web3Provider.Consumer>
-    {({ state: { web3, networkName }, actions: { setProvider } }) => (
-      <AccountModal
-        web3={web3}
-        networkName={networkName}
-        open={open}
-        onProviderSet={onProviderSet}
-        setProvider={setProvider}
-      />
-    )}
+    {
+        ({
+          state: { web3, networkName },
+          actions: { setProvider },
+          availableProviders,
+        }) => (
+          <AccountModal
+            web3={web3}
+            networkName={networkName}
+            open={open}
+            onProviderSet={onProviderSet}
+            setProvider={setProvider}
+            availableProviders={availableProviders}
+            handleClose={handleOnClose}
+          />
+        )
+      }
   </Web3Provider.Consumer>
 )
 

--- a/src/components/hoc/WithAccount.tsx
+++ b/src/components/hoc/WithAccount.tsx
@@ -28,6 +28,7 @@ const WithAccount = ({ WrappedComponent, onChange }) => {
       <LoginModal
         open={modalOpened}
         onProviderSet={onProviderSet}
+        handleOnClose={() => setModalOpened(false)}
       />
       <WrappedComponent onChange={handleOnChange} />
     </>

--- a/src/components/organisms/TransactionInProgressPanel.tsx
+++ b/src/components/organisms/TransactionInProgressPanel.tsx
@@ -1,12 +1,17 @@
-import React, { FC } from 'react'
+import React, { FC, useContext, useEffect } from 'react'
 import {
   CircularProgress, createStyles, makeStyles, Theme,
 } from '@material-ui/core'
-import { Typography } from '@rsksmart/rif-ui'
+import { Typography, shortenAddress } from '@rsksmart/rif-ui'
+import BlockchainStore, { BlockchainStoreProps } from 'store/Blockchain/BlockchainStore'
+import MarketStore from 'store/Market/MarketStore'
+import { BLOCKCHAIN_ACTIONS } from 'store/Blockchain/blockchainActions'
+import { MARKET_ACTIONS } from 'store/Market/marketActions'
 
 export interface TransactionInProgressPanelProps {
   text: string
   progMsg: string
+  isPendingConfirm?: boolean
 }
 
 const useStyles = makeStyles((theme: Theme) => createStyles({
@@ -21,11 +26,37 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
   },
 }))
 
-const TransactionInProgressPanel: FC<TransactionInProgressPanelProps> = ({ progMsg, text }) => {
+const TransactionInProgressPanel: FC<TransactionInProgressPanelProps> = ({ progMsg, text, isPendingConfirm }) => {
   const classes = useStyles()
+
+  const { state: { confirmations: { txHash, currentCount, targetCount } }, dispatch: bcDispatch }: BlockchainStoreProps = useContext(BlockchainStore)
+  const { dispatch: mDispatch } = useContext(MarketStore)
+
+  useEffect(() => {
+    if (currentCount && targetCount && currentCount >= targetCount) {
+      bcDispatch({
+        type: BLOCKCHAIN_ACTIONS.CLEAR_CONFIRMATIONS,
+        payload: {} as any,
+      })
+    }
+  }, [currentCount, targetCount, bcDispatch])
+
+  useEffect(() => {
+    if (isPendingConfirm && !txHash) {
+      mDispatch({
+        type: MARKET_ACTIONS.SET_PROG_STATUS,
+        payload: {
+          isProcessing: false,
+        },
+      })
+    }
+  }, [txHash, isPendingConfirm, mDispatch])
+
   return (
     <div className={classes.content}>
       <Typography>{text}</Typography>
+      {txHash && !currentCount && <Typography>{`Transaction ${shortenAddress(txHash)} is waiting for the first confirmation.`}</Typography>}
+      {txHash && currentCount && <Typography>{`Transaction ${shortenAddress(txHash)} is waiting for confirmation ${currentCount + 1} of ${targetCount}.`}</Typography>}
       <CircularProgress />
       <Typography>{progMsg}</Typography>
     </div>

--- a/src/components/organisms/rns/sell/MyDomains.tsx
+++ b/src/components/organisms/rns/sell/MyDomains.tsx
@@ -47,7 +47,7 @@ const MyDomains: FC<{}> = () => {
         },
       })
     }
-  }, [account, dispatch, servicePath])
+  }, [account, servicePath, dispatch])
 
   // fetch domains based on the statusFilter
   useEffect(() => {
@@ -61,7 +61,7 @@ const MyDomains: FC<{}> = () => {
           },
         }))
     }
-  }, [account, dispatch, domainFilters, ownerAddress, servicePath])
+  }, [domainFilters, servicePath, ownerAddress, dispatch])
 
   useEffect(() => {
     if (account) {

--- a/src/components/organisms/rns/sell/MyOffers.tsx
+++ b/src/components/organisms/rns/sell/MyOffers.tsx
@@ -52,7 +52,7 @@ const MyOffers: FC<{}> = () => {
         },
       })
     }
-  }, [account, dispatch, servicePath])
+  }, [account, servicePath, dispatch])
 
   // fetch domains based on the statusFilter
   useEffect(() => {

--- a/src/components/organisms/rns/sell/SoldDomains.tsx
+++ b/src/components/organisms/rns/sell/SoldDomains.tsx
@@ -49,7 +49,7 @@ const SoldDomains: FC<{}> = () => {
         },
       })
     }
-  }, [account, dispatch, servicePath])
+  }, [account, servicePath, dispatch])
 
   // fetchSoldDomains and dispatch set items
   useEffect(() => {
@@ -62,7 +62,7 @@ const SoldDomains: FC<{}> = () => {
           },
         }))
     }
-  }, [account, dispatch, domainFilters, ownerAddress, servicePath])
+  }, [servicePath, ownerAddress, domainFilters, dispatch])
 
   useEffect(() => {
     if (account) {

--- a/src/components/pages/rns/buy/DomainOffersCheckoutPage.tsx
+++ b/src/components/pages/rns/buy/DomainOffersCheckoutPage.tsx
@@ -179,7 +179,15 @@ const DomainOffersCheckoutPage: FC<{}> = () => {
         const tokenPlacement = await marketPlaceContract.methods.placement(tokenId).call({ from: account })
         const tokenPrice = tokenPlacement[1]
 
-        const transferReceipt = await rifContract.methods.transferAndCall(marketPlaceAddress, tokenPrice, tokenId).send({ from: account })
+        // Get gas price
+        const gasPrice = await web3.eth.getGasPrice()
+
+        // Get gas limit for Payment transaction
+        const estimatedGas = await rifContract.methods.transferAndCall(marketPlaceAddress, tokenPrice, tokenId).estimateGas({ from: account, gasPrice })
+        const gas = Math.floor(estimatedGas * 1.1)
+
+        // Payment transaction
+        const transferReceipt = await rifContract.methods.transferAndCall(marketPlaceAddress, tokenPrice, tokenId).send({ from: account, gas, gasPrice })
         logger.info('transferReceipt:', transferReceipt)
 
         if (!transferReceipt) {

--- a/src/components/pages/rns/buy/DomainOffersPage.tsx
+++ b/src/components/pages/rns/buy/DomainOffersPage.tsx
@@ -69,7 +69,7 @@ const DomainOffersPage: FC = () => {
           },
         }))
     }
-  }, [offerFilters, dispatch, servicePath])
+  }, [offerFilters, servicePath, dispatch])
 
   // if wrong type, ignore this render
   if (!currentListing || currentListing?.listingType !== LISTING_TYPE) return null

--- a/src/components/pages/rns/buy/DomainPurchased.tsx
+++ b/src/components/pages/rns/buy/DomainPurchased.tsx
@@ -2,9 +2,14 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core'
 import { Button } from '@rsksmart/rif-ui'
 import JobDoneBox from 'components/molecules/JobDoneBox'
 import TxCompletePageTemplate from 'components/templates/TxCompletePageTemplate'
-import React, { FC } from 'react'
+import React, { FC, useContext } from 'react'
 import { useHistory } from 'react-router-dom'
 import ROUTES from 'routes'
+import MarketStore from 'store/Market/MarketStore'
+import networkConfig from 'ui-config.json'
+
+const network: string = process.env.REACT_APP_NETWORK || 'ganache'
+const { rnsManagerUrl } = networkConfig[network]
 
 const useStyles = makeStyles((theme: Theme) => createStyles({
   actions: {
@@ -20,6 +25,14 @@ const DomainPurchased: FC<{}> = () => {
   const classes = useStyles()
   const history = useHistory()
 
+  const {
+    state: {
+      currentOrder,
+    },
+  } = useContext(MarketStore)
+
+  const { item: { domainName } } = currentOrder
+
   return (
     <TxCompletePageTemplate>
       <JobDoneBox text="Your domain has been bought." />
@@ -30,9 +43,7 @@ const DomainPurchased: FC<{}> = () => {
           variant="contained"
           rounded
           shadow
-          disabled
-          onClick={() => { alert('This should take you to the RNS admin page.') }} // eslint-disable-line no-alert
-        // FIXME: do the correct navigation here
+          onClick={() => { window.open(`${rnsManagerUrl}?autologin=${domainName}`, '_blank') }}
         >
           Admin my domain
         </Button>

--- a/src/components/pages/rns/buy/DomainPurchased.tsx
+++ b/src/components/pages/rns/buy/DomainPurchased.tsx
@@ -7,6 +7,7 @@ import { useHistory } from 'react-router-dom'
 import ROUTES from 'routes'
 import MarketStore from 'store/Market/MarketStore'
 import networkConfig from 'ui-config.json'
+import validUrl from 'valid-url'
 
 const network: string = process.env.REACT_APP_NETWORK || 'ganache'
 const { rnsManagerUrl } = networkConfig[network]
@@ -42,6 +43,7 @@ const DomainPurchased: FC<{}> = () => {
           color="primary"
           variant="contained"
           rounded
+          disabled={!validUrl.isUri(rnsManagerUrl)}
           shadow
           onClick={() => { window.open(`${rnsManagerUrl}?autologin=${domainName}`, '_blank') }}
         >

--- a/src/components/pages/rns/cancel/CancelDomainCheckoutPage.tsx
+++ b/src/components/pages/rns/cancel/CancelDomainCheckoutPage.tsx
@@ -137,10 +137,19 @@ const CancelDomainCheckoutPage = () => {
         const rnsContract = getRnsContract(web3)
         const marketPlaceContract = getMarketplaceContract(web3)
 
-        const unapproveReceipt = await rnsContract.methods.approve('0x0000000000000000000000000000000000000000', tokenId).send({ from: account })
-        logger.info('unapproveReciept:', unapproveReceipt)
+        // Get gas price
+        const gasPrice = await web3.eth.getGasPrice()
 
-        const receipt = await marketPlaceContract.methods.unplace(tokenId).send({ from: account })
+        // Send unapproval transaction
+        const unapproveReceipt = await rnsContract.methods.approve('0x0000000000000000000000000000000000000000', tokenId).send({ from: account, gasPrice })
+        logger.info('unapproveReceipt:', unapproveReceipt)
+
+        // Get gas limit for unplacement transaction
+        const estimatedGas = await marketPlaceContract.methods.unplace(tokenId).estimateGas({ from: account, gasPrice })
+        const gas = Math.floor(estimatedGas * 1.1)
+
+        // Send unplacement transaction
+        const receipt = await marketPlaceContract.methods.unplace(tokenId).send({ from: account, gas, gasPrice })
         logger.info('unplace receipt:', receipt)
 
         if (!receipt) {

--- a/src/components/pages/rns/sell/DomainCheckoutPage.tsx
+++ b/src/components/pages/rns/sell/DomainCheckoutPage.tsx
@@ -140,10 +140,20 @@ const DomainsCheckoutPage: FC<{}> = () => {
       try {
         const rnsContract = getRnsContract(web3)
         const marketPlaceContract = getMarketplaceContract(web3)
+
+        // Get gas price
+        const gasPrice = await web3.eth.getGasPrice()
+
+        // Send approval transaction
         const approveReceipt = await rnsContract.methods.approve(marketPlaceAddress, tokenId).send({ from: account })
         logger.info('approveReciept:', approveReceipt)
 
-        const receipt = await marketPlaceContract.methods.place(tokenId, rifTokenAddress, web3.utils.toWei(price)).send({ from: account })
+        // Get gas limit for Placement
+        const estimatedGas = await marketPlaceContract.methods.place(tokenId, rifTokenAddress, web3.utils.toWei(price)).estimateGas({ from: account, gasPrice })
+        const gas = Math.floor(estimatedGas * 1.1)
+
+        // Send Placement transaction
+        const receipt = await marketPlaceContract.methods.place(tokenId, rifTokenAddress, web3.utils.toWei(price)).send({ from: account, gas, gasPrice })
         logger.info('place receipt:', receipt)
 
         if (!receipt) {

--- a/src/components/templates/CheckoutPageTemplate.tsx
+++ b/src/components/templates/CheckoutPageTemplate.tsx
@@ -34,7 +34,7 @@ const CheckoutPageTemplate: FC<CheckoutPageTemplateProps> = ({ className = '', b
   const { state: { currentOrder }, dispatch } = useContext(MarketStore)
 
   useEffect(() => () => {
-    dispatch({ type: MARKET_ACTIONS.CLEAN_UP, payload: { currentListing: true, currentOrder: true } })
+    dispatch({ type: MARKET_ACTIONS.CLEAN_UP, payload: { currentListing: true } })
   }, [dispatch])
 
   return (

--- a/src/components/templates/TxCompletePageTemplate.tsx
+++ b/src/components/templates/TxCompletePageTemplate.tsx
@@ -1,6 +1,8 @@
-import React, { FC } from 'react'
+import React, { FC, useContext, useEffect } from 'react'
 import { createStyles, makeStyles } from '@material-ui/core'
 import { doneThumbsUpImg } from '@rsksmart/rif-ui'
+import { MARKET_ACTIONS } from 'store/Market/marketActions'
+import MarketStore from 'store/Market/MarketStore'
 
 const useStyles = makeStyles(() => createStyles({
   body: {
@@ -16,6 +18,12 @@ const useStyles = makeStyles(() => createStyles({
 
 const TxCompletePageTemplate: FC<{}> = ({ children }) => {
   const classes = useStyles()
+
+  const { dispatch } = useContext(MarketStore)
+
+  useEffect(() => () => {
+    dispatch({ type: MARKET_ACTIONS.CLEAN_UP, payload: { currentOrder: true } })
+  }, [dispatch])
 
   return (
     <div className={classes.body}>

--- a/src/store/App/AppStore.tsx
+++ b/src/store/App/AppStore.tsx
@@ -1,25 +1,42 @@
+import { Application, Service } from '@feathersjs/feathers'
+import { ConfirmationsController } from 'api/rif-marketplace-cache/confirmationsController'
 import React, { Dispatch, useReducer } from 'react'
 import { AppAction } from './appActions'
 import appReducer from './appReducer'
 
-export interface AppStateType {
+export interface ServiceEventListener {
+  (...args: any[]): void
+}
+
+export interface APIController {
+  path: string
+  service: Service<any>
+  connect: (client: Application<any>) => string | void
+  fetch: (filters?) => Promise<any>
+  attachEvent: (name: string, callback: ServiceEventListener) => void
+  detachEvent: (name: string) => void
+}
+
+export type ServiceMap = Map<string, APIController>
+
+export interface AppState {
   isError?: boolean
   isLoading?: boolean
   message?: string
   formError?: any
+  apis: ServiceMap
 }
 
-interface AppStorePropsType {
-  state: {
-    message: AppStateType
-  }
+export interface AppStoreProps {
+  state: AppState
   dispatch: Dispatch<AppAction>
 }
 
-export const initialState: AppStateType = {
+export const initialState: AppState = {
+  apis: new Map([['confirmations', new ConfirmationsController()]]),
 }
 
-const AppStore = React.createContext({} as AppStorePropsType | any)
+const AppStore = React.createContext({} as AppStoreProps | any)
 
 export const AppStoreProvider = ({ children }) => {
   const [state, dispatch] = useReducer(appReducer, initialState)

--- a/src/store/App/appReducer.ts
+++ b/src/store/App/appReducer.ts
@@ -3,7 +3,7 @@ import {
 } from 'store/App/appActions'
 import Logger from 'utils/Logger'
 import { APP_ACTIONS } from './appActions'
-import { AppStateType, initialState } from './AppStore'
+import { AppState, initialState } from './AppStore'
 
 const logger = Logger.getInstance()
 
@@ -46,5 +46,5 @@ const appReducer = (state = initialState, action: AppAction) => {
 export default appReducer
 
 type IAppActions = {
-  [key in APP_ACTIONS]: (state: AppStateType, payload: AppPayload) => AppStateType
+  [key in APP_ACTIONS]: (state: AppState, payload: AppPayload) => AppState
 }

--- a/src/store/Blockchain/BlockchainStore.tsx
+++ b/src/store/Blockchain/BlockchainStore.tsx
@@ -1,0 +1,90 @@
+import { Web3Store } from '@rsksmart/rif-ui'
+import client from 'api/rif-marketplace-cache/config'
+import { ConfirmationAPI, ConfirmationsItem, mapFromTransport } from 'api/rif-marketplace-cache/confirmationsController'
+import React, {
+  createContext, Dispatch, useContext, useEffect, useReducer,
+} from 'react'
+import AppStore, { AppStoreProps } from 'store/App/AppStore'
+import { BlockchainAction, BLOCKCHAIN_ACTIONS } from './blockchainActions'
+import blockchainReducer from './blockchainReducer'
+
+type Modify<T, R> = Omit<T, keyof R> & R;
+
+export interface BlockchainState {
+  confirmations: Modify<Partial<ConfirmationsItem>, {
+    txHash?: string
+    isConnected?: boolean
+  }>
+}
+
+export interface BlockchainStoreProps {
+  state: BlockchainState
+  dispatch: Dispatch<BlockchainAction>
+}
+
+export const initialState: BlockchainState = {
+  confirmations: {},
+}
+
+const BlockchainStore = createContext({} as BlockchainStoreProps | any)
+
+export const BlockchainStoreProvider = ({ children }) => {
+  const [state, dispatch] = useReducer(blockchainReducer, initialState)
+  const { state: { apis } }: AppStoreProps = useContext(AppStore)
+  const { state: { account } } = useContext(Web3Store)
+  const confirmationsAPI = apis.get('confirmations') as ConfirmationAPI
+  const {
+    confirmations: {
+      txHash, currentCount: storedCurrentCt, targetCount: storedTargetCt, isConnected,
+    },
+  } = state
+
+  useEffect(() => {
+    if (storedCurrentCt && storedTargetCt) {
+      if (storedCurrentCt >= storedTargetCt) {
+        dispatch({
+          type: BLOCKCHAIN_ACTIONS.SET_TX_HASH,
+          payload: {
+            txHash: undefined,
+          } as any,
+        })
+      }
+    }
+  }, [storedCurrentCt, storedTargetCt])
+
+  useEffect(() => {
+    if (isConnected && txHash) {
+      confirmationsAPI.attachEvent('newConfirmation', (result) => {
+        const confs = mapFromTransport([result])
+        const currentTx = confs[txHash as string]
+
+        if (currentTx) {
+          dispatch({
+            type: BLOCKCHAIN_ACTIONS.SET_CONFIRMATIONS,
+            payload: currentTx as any,
+          })
+        }
+      })
+    }
+  }, [isConnected, txHash, confirmationsAPI])
+
+  useEffect(() => {
+    if (account) {
+      if (confirmationsAPI) {
+        const connected = !!confirmationsAPI.connect(client)
+
+        if (connected) {
+          dispatch({
+            type: BLOCKCHAIN_ACTIONS.CONNECT_CONFIRMATIONS,
+            payload: { isConnected: connected } as any,
+          })
+        }
+      }
+    }
+  }, [account, confirmationsAPI])
+
+  const value = { state, dispatch }
+  return <BlockchainStore.Provider value={value}>{children}</BlockchainStore.Provider>
+}
+
+export default BlockchainStore

--- a/src/store/Blockchain/blockchainActions.ts
+++ b/src/store/Blockchain/blockchainActions.ts
@@ -1,0 +1,26 @@
+import { ConfirmationsItem } from 'api/rif-marketplace-cache/confirmationsController'
+import { ActionType } from 'store/storeUtils/interfaces'
+
+export enum BLOCKCHAIN_ACTIONS {
+    NOOP = 'NOOP',
+    SET_CONFIRMATIONS = 'SET_CONFIRMATIONS',
+    CONNECT_CONFIRMATIONS = 'CONNECT_CONFIRMATIONS',
+    SET_TX_HASH = 'SET_TX_HASH',
+    CLEAR_CONFIRMATIONS = 'CLEAR_CONFIRMATIONS'
+}
+
+export interface AddTxPayload {
+    txHash: string
+}
+
+export type ConfirmationsPayload = ConfirmationsItem
+
+export interface ConnectionPayload {
+    isConnected: boolean
+}
+
+export type BlockchainPayload = ConfirmationsPayload & ConnectionPayload & AddTxPayload
+
+export interface BlockchainAction extends ActionType<BlockchainPayload> {
+    type: BLOCKCHAIN_ACTIONS
+}

--- a/src/store/Blockchain/blockchainReducer.ts
+++ b/src/store/Blockchain/blockchainReducer.ts
@@ -1,0 +1,76 @@
+import { initialState } from 'store/Blockchain/BlockchainStore'
+import Logger from 'utils/Logger'
+import {
+  BlockchainAction, BlockchainPayload, BLOCKCHAIN_ACTIONS, ConfirmationsPayload, ConnectionPayload, AddTxPayload,
+} from './blockchainActions'
+import { BlockchainState } from './BlockchainStore'
+
+const logger = Logger.getInstance()
+
+const {
+  CLEAR_CONFIRMATIONS,
+  CONNECT_CONFIRMATIONS,
+  NOOP,
+  SET_CONFIRMATIONS,
+  SET_TX_HASH,
+} = BLOCKCHAIN_ACTIONS
+
+type IBlockchainActions = {
+  [key in BLOCKCHAIN_ACTIONS]: (state: BlockchainState, payload: BlockchainPayload) => BlockchainState
+}
+
+const blockchainActions: IBlockchainActions = {
+  [NOOP]: (state, _) => state,
+  [SET_TX_HASH]: (state, payload: AddTxPayload) => {
+    const { txHash } = payload
+    const { confirmations: { isConnected } } = state
+    return {
+      ...state,
+      confirmations: { isConnected, txHash },
+    }
+  },
+  [SET_CONFIRMATIONS]: (state, payload: ConfirmationsPayload) => {
+    const { currentCount, targetCount } = payload
+    const { confirmations } = state
+
+    return {
+      ...state,
+      confirmations: {
+        ...confirmations,
+        currentCount,
+        targetCount,
+      },
+    }
+  },
+  [CONNECT_CONFIRMATIONS]: (state, payload: ConnectionPayload) => {
+    const { isConnected } = payload
+
+    return {
+      ...state,
+      confirmations: {
+        isConnected,
+      },
+    }
+  },
+  [CLEAR_CONFIRMATIONS]: (state, _: BlockchainPayload) => ({ ...state, confirmations: { isConnected: state.confirmations.isConnected } }),
+
+}
+
+// TODO: Extract reusable
+const blockchainReducer = (state = initialState, action: BlockchainAction) => {
+  const { type, payload } = action
+  const userAction = blockchainActions[type]
+
+  logger.debug('Blockchain action:', action)
+  const newState = (!!userAction && userAction(state, payload)) || state
+
+  if (state !== newState) {
+    logger.debug('Prev state:', state)
+    logger.debug('Next state:', newState)
+  } else {
+    logger.debug('No change:', newState)
+  }
+
+  return newState
+}
+export default blockchainReducer

--- a/src/store/Market/marketActions.ts
+++ b/src/store/Market/marketActions.ts
@@ -8,6 +8,7 @@ export enum MARKET_ACTIONS {
   NOOP = 'NOOP',
   SET_ITEMS = 'SET_ITEMS',
   SELECT_ITEM = 'SELECT_ITEM',
+  SET_PROG_STATUS = 'SET_PROG_STATUS',
   SET_FILTER = 'SET_FILTER',
   TOGGLE_TX_TYPE = 'TOGGLE_TX_TYPE',
   CONNECT_SERVICE = 'CONNECT_SERVICE',
@@ -45,6 +46,10 @@ export interface ExchangeRatePayload {
   }
 }
 
+export interface ProgressStatusPayload {
+  isProcessing: boolean
+}
+
 export interface MetadataPayload {
   updatedTokenId: string
 }
@@ -58,7 +63,7 @@ export interface TxTypeChangePayload {
   txType: TxType
 }
 
-export type MarketPayloadType = ItemPayload & FilterPayload & ConnectionPayload & TxTypeChangePayload & ExchangeRatePayload & ListingPayload & MetadataPayload & CleanupPayload
+export type MarketPayloadType = ItemPayload & FilterPayload & ConnectionPayload & TxTypeChangePayload & ExchangeRatePayload & ListingPayload & MetadataPayload & CleanupPayload & ProgressStatusPayload
 
 export interface MarketAction extends ActionType<MarketPayloadType> {
   type: MARKET_ACTIONS

--- a/src/store/Market/marketReducer.ts
+++ b/src/store/Market/marketReducer.ts
@@ -11,6 +11,7 @@ import {
   ExchangeRatePayload,
   MetadataPayload,
   CleanupPayload,
+  ProgressStatusPayload,
 } from './marketActions'
 import { MarketStateType, initialState } from './MarketStore'
 
@@ -20,6 +21,7 @@ const {
   NOOP,
   SET_ITEMS,
   SELECT_ITEM,
+  SET_PROG_STATUS,
   SET_FILTER,
   TOGGLE_TX_TYPE,
   CONNECT_SERVICE,
@@ -58,6 +60,20 @@ const marketActions: MarketActionsType = {
   [SELECT_ITEM]: (state: MarketStateType, payload: ItemPayload) => ({
     ...state, currentOrder: { ...payload },
   }),
+  [SET_PROG_STATUS]: (state: MarketStateType, payload: ProgressStatusPayload) => {
+    const { isProcessing } = payload
+    const { currentOrder } = state
+
+    if (!currentOrder) return state
+
+    return {
+      ...state,
+      currentOrder: {
+        ...currentOrder,
+        isProcessing,
+      },
+    }
+  },
   [SET_FILTER]: (state: MarketStateType, payload: FilterPayload) => {
     const { filters, currentListing } = state
 

--- a/src/ui-config.json
+++ b/src/ui-config.json
@@ -2,11 +2,13 @@
     "ganache": {
         "rif": "0x67B5656d60a809915323Bf2C40A8bEF15A152e3e",
         "rnsDotRskOwner": "0x4bf749ec68270027C5910220CEAB30Cc284c7BA2",
-        "marketplace": "0x31630Dba815db73E9e0Fe16a4F42dF4bbFDB7Ba9"
+        "marketplace": "0x31630Dba815db73E9e0Fe16a4F42dF4bbFDB7Ba9",
+        "rnsManagerUrl": "http://localhost:3001"
     },
     "rsktestnet": {
         "rif": "0x19f64674D8a5b4e652319F5e239EFd3bc969a1FE",
         "rnsDotRskOwner": "0xca0a477e19bac7e0e172ccfd2e3c28a7200bdb71",
-        "marketplace": "0xe93EE0Ac6C97807F4c28f66cA44E1Ad18E485033"
+        "marketplace": "0xe93EE0Ac6C97807F4c28f66cA44E1Ad18E485033",
+        "rnsManagerUrl": "https://testnet.manager.rns.rifos.org"
     }
 }


### PR DESCRIPTION
* Adds link to RNS Manager after you Buy a domain.
* RNS Manager URL has to be defined in the `ui-config.json` file.
* Checks that the URL is valid otherwise disables the button.
* Postpones Cleanup of `currentOrder` to the Transaction confirmation page.

Note: To test this PR you need to:
1) Run the RNS Manager locally with the LATEST `develop` branch.
2) If you get an error when doing `npm start` in the RNS manager run: `npm i webpack@4.28.3` in the Manager project this should fix the issue. Then try again.
3) Setup the correct RNS manager URL in the `ui-config.json` file of the MArketplace UI project. (samples provided in the default file).

4) **BUY** a domain and then click on the `Admin my domain` button of the confirmation page. You should get a new tab opened directly on the manager page (if you didnt switch the account in between, you have to be with the samne account that just bought the domain)