### PR TITLE
feat: calculate gas limit and gas price for txs

### DIFF
--- a/src/components/pages/rns/buy/DomainOffersCheckoutPage.tsx
+++ b/src/components/pages/rns/buy/DomainOffersCheckoutPage.tsx
@@ -179,7 +179,15 @@ const DomainOffersCheckoutPage: FC<{}> = () => {
         const tokenPlacement = await marketPlaceContract.methods.placement(tokenId).call({ from: account })
         const tokenPrice = tokenPlacement[1]
 
-        const transferReceipt = await rifContract.methods.transferAndCall(marketPlaceAddress, tokenPrice, tokenId).send({ from: account })
+        // Get gas price
+        const gasPrice = await web3.eth.getGasPrice()
+
+        // Get gas limit for Payment transaction
+        const estimatedGas = await rifContract.methods.transferAndCall(marketPlaceAddress, tokenPrice, tokenId).estimateGas({ from: account, gasPrice })
+        const gas = Math.floor(estimatedGas * 1.1)
+
+        // Payment transaction
+        const transferReceipt = await rifContract.methods.transferAndCall(marketPlaceAddress, tokenPrice, tokenId).send({ from: account, gas, gasPrice })
         logger.info('transferReceipt:', transferReceipt)
 
         if (!transferReceipt) {

--- a/src/components/pages/rns/cancel/CancelDomainCheckoutPage.tsx
+++ b/src/components/pages/rns/cancel/CancelDomainCheckoutPage.tsx
@@ -137,10 +137,19 @@ const CancelDomainCheckoutPage = () => {
         const rnsContract = getRnsContract(web3)
         const marketPlaceContract = getMarketplaceContract(web3)
 
-        const unapproveReceipt = await rnsContract.methods.approve('0x0000000000000000000000000000000000000000', tokenId).send({ from: account })
-        logger.info('unapproveReciept:', unapproveReceipt)
+        // Get gas price
+        const gasPrice = await web3.eth.getGasPrice()
 
-        const receipt = await marketPlaceContract.methods.unplace(tokenId).send({ from: account })
+        // Send unapproval transaction
+        const unapproveReceipt = await rnsContract.methods.approve('0x0000000000000000000000000000000000000000', tokenId).send({ from: account, gasPrice })
+        logger.info('unapproveReceipt:', unapproveReceipt)
+
+        // Get gas limit for unplacement transaction
+        const estimatedGas = await marketPlaceContract.methods.unplace(tokenId).estimateGas({ from: account, gasPrice })
+        const gas = Math.floor(estimatedGas * 1.1)
+
+        // Send unplacement transaction
+        const receipt = await marketPlaceContract.methods.unplace(tokenId).send({ from: account, gas, gasPrice })
         logger.info('unplace receipt:', receipt)
 
         if (!receipt) {

--- a/src/components/pages/rns/sell/DomainCheckoutPage.tsx
+++ b/src/components/pages/rns/sell/DomainCheckoutPage.tsx
@@ -140,10 +140,20 @@ const DomainsCheckoutPage: FC<{}> = () => {
       try {
         const rnsContract = getRnsContract(web3)
         const marketPlaceContract = getMarketplaceContract(web3)
+
+        // Get gas price
+        const gasPrice = await web3.eth.getGasPrice()
+
+        // Send approval transaction
         const approveReceipt = await rnsContract.methods.approve(marketPlaceAddress, tokenId).send({ from: account })
         logger.info('approveReciept:', approveReceipt)
 
-        const receipt = await marketPlaceContract.methods.place(tokenId, rifTokenAddress, web3.utils.toWei(price)).send({ from: account })
+        // Get gas limit for Placement
+        const estimatedGas = await marketPlaceContract.methods.place(tokenId, rifTokenAddress, web3.utils.toWei(price)).estimateGas({ from: account, gasPrice })
+        const gas = Math.floor(estimatedGas * 1.1)
+
+        // Send Placement transaction
+        const receipt = await marketPlaceContract.methods.place(tokenId, rifTokenAddress, web3.utils.toWei(price)).send({ from: account, gas, gasPrice })
         logger.info('place receipt:', receipt)
 
         if (!receipt) {


### PR DESCRIPTION
* Calculate for each major transaction the `gas` and `gasPrice` values to send in the TX. This enables transactions to be executed and picked up by miners avoiding long waits when sending Tx to the blockchain. Critical for Testnet and Mainnet.

Note: In a future change we can refactor to a utils class instead of doing the logic in each phase.