### PR TITLE
feat/ Admin your domain option after purchase

### DIFF
--- a/src/components/pages/rns/buy/DomainOffersCheckoutPage.tsx
+++ b/src/components/pages/rns/buy/DomainOffersCheckoutPage.tsx
@@ -95,16 +95,15 @@ const DomainOffersCheckoutPage: FC<{}> = () => {
 
   const [hasFunds, setHasFunds] = useState(false)
   const [isFundsConfirmed, setIsFundsConfirmed] = useState(false)
+  const tokenId = currentOrder?.item?.tokenId
+  const domainName = currentOrder?.item?.domainName
 
   // check funds
   useEffect(() => {
-    if (web3 && account && currentOrder?.item?.tokenId) {
-      setIsFundsConfirmed(false)
-      const { item: { tokenId } } = currentOrder
+    if (account && tokenId && !isFundsConfirmed) {
       const checkFunds = async () => {
         const rifContract = getRifContract(web3)
         const marketPlaceContract = getMarketplaceContract(web3)
-
         try {
           const myBalance = await rifContract.methods.balanceOf(account).call({ from: account })
           const tokenPlacement = await marketPlaceContract.methods.placement(tokenId).call({ from: account })
@@ -118,7 +117,7 @@ const DomainOffersCheckoutPage: FC<{}> = () => {
       }
       checkFunds()
     }
-  }, [web3, account, currentOrder])
+  }, [web3, account, tokenId, isFundsConfirmed])
 
   useEffect(() => {
     if (!currentOrder) {
@@ -131,8 +130,6 @@ const DomainOffersCheckoutPage: FC<{}> = () => {
   }, [currentOrder, isPendingConfirm, history])
 
   if (!currentOrder) return null
-
-  const { item: { domainName, tokenId } } = currentOrder
 
   const {
     item: {

--- a/src/components/pages/rns/buy/DomainPurchased.tsx
+++ b/src/components/pages/rns/buy/DomainPurchased.tsx
@@ -2,9 +2,14 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core'
 import { Button } from '@rsksmart/rif-ui'
 import JobDoneBox from 'components/molecules/JobDoneBox'
 import TxCompletePageTemplate from 'components/templates/TxCompletePageTemplate'
-import React, { FC } from 'react'
+import React, { FC, useContext } from 'react'
 import { useHistory } from 'react-router-dom'
 import ROUTES from 'routes'
+import MarketStore from 'store/Market/MarketStore'
+import networkConfig from 'ui-config.json'
+
+const network: string = process.env.REACT_APP_NETWORK || 'ganache'
+const { rnsManagerUrl } = networkConfig[network]
 
 const useStyles = makeStyles((theme: Theme) => createStyles({
   actions: {
@@ -20,6 +25,14 @@ const DomainPurchased: FC<{}> = () => {
   const classes = useStyles()
   const history = useHistory()
 
+  const {
+    state: {
+      currentOrder,
+    },
+  } = useContext(MarketStore)
+
+  const { item: { domainName } } = currentOrder
+
   return (
     <TxCompletePageTemplate>
       <JobDoneBox text="Your domain has been bought." />
@@ -30,9 +43,8 @@ const DomainPurchased: FC<{}> = () => {
           variant="contained"
           rounded
           shadow
-          disabled
-          onClick={() => { alert('This should take you to the RNS admin page.') }} // eslint-disable-line no-alert
-        // FIXME: do the correct navigation here
+          disabled={!rnsManagerUrl}
+          onClick={() => { window.open(`${rnsManagerUrl}?autologin=${domainName}`, '_blank') }}
         >
           Admin my domain
         </Button>

--- a/src/components/templates/CheckoutPageTemplate.tsx
+++ b/src/components/templates/CheckoutPageTemplate.tsx
@@ -34,7 +34,7 @@ const CheckoutPageTemplate: FC<CheckoutPageTemplateProps> = ({ className = '', b
   const { state: { currentOrder }, dispatch } = useContext(MarketStore)
 
   useEffect(() => () => {
-    dispatch({ type: MARKET_ACTIONS.CLEAN_UP, payload: { currentListing: true, currentOrder: true } })
+    dispatch({ type: MARKET_ACTIONS.CLEAN_UP, payload: { currentListing: true } })
   }, [dispatch])
 
   return (

--- a/src/components/templates/TxCompletePageTemplate.tsx
+++ b/src/components/templates/TxCompletePageTemplate.tsx
@@ -1,6 +1,8 @@
-import React, { FC } from 'react'
+import React, { FC, useContext, useEffect } from 'react'
 import { createStyles, makeStyles } from '@material-ui/core'
 import { doneThumbsUpImg } from '@rsksmart/rif-ui'
+import { MARKET_ACTIONS } from 'store/Market/marketActions'
+import MarketStore from 'store/Market/MarketStore'
 
 const useStyles = makeStyles(() => createStyles({
   body: {
@@ -16,6 +18,12 @@ const useStyles = makeStyles(() => createStyles({
 
 const TxCompletePageTemplate: FC<{}> = ({ children }) => {
   const classes = useStyles()
+
+  const { dispatch } = useContext(MarketStore)
+
+  useEffect(() => () => {
+    dispatch({ type: MARKET_ACTIONS.CLEAN_UP, payload: { currentOrder: true } })
+  }, [dispatch])
 
   return (
     <div className={classes.body}>

--- a/src/ui-config.json
+++ b/src/ui-config.json
@@ -2,11 +2,13 @@
     "ganache": {
         "rif": "0x67B5656d60a809915323Bf2C40A8bEF15A152e3e",
         "rnsDotRskOwner": "0x4bf749ec68270027C5910220CEAB30Cc284c7BA2",
-        "marketplace": "0x31630Dba815db73E9e0Fe16a4F42dF4bbFDB7Ba9"
+        "marketplace": "0x31630Dba815db73E9e0Fe16a4F42dF4bbFDB7Ba9",
+        "rnsManagerUrl": "http://localhost:3001"
     },
     "rsktestnet": {
         "rif": "0x19f64674D8a5b4e652319F5e239EFd3bc969a1FE",
         "rnsDotRskOwner": "0xca0a477e19bac7e0e172ccfd2e3c28a7200bdb71",
-        "marketplace": "0xe93EE0Ac6C97807F4c28f66cA44E1Ad18E485033"
+        "marketplace": "0xe93EE0Ac6C97807F4c28f66cA44E1Ad18E485033",
+        "rnsManagerUrl": "https://marketplace.testnet.rns.rifos.org"
     }
 }


### PR DESCRIPTION
Closes #139 

* Adds link to RNS Manager after you Buy a domain.
* RNS Manager URL has to be defined in the `ui-config.json` file.
* Checks that the URL is defined.
* Postpones Cleanup of `currentOrder` to the Transaction confirmation page.

Note: To test this PR you need to:
1) Run the RNS Manager locally with the LATEST `develop` branch.
2) If you get an error when doing `npm start` in the RNS manager run: `npm i webpack@4.28.3` in the Manager project this should fix the issue. Then try again.
3) Setup the correct RNS manager URL in the `ui-config.json` file of the MArketplace UI project. (samples provided in the default file).

4) **BUY** a domain and then click on the `Admin my domain` button of the confirmation page. You should get a new tab opened directly on the manager page (if you didnt switch the account in between, you have to be with the same account that just bought the domain)