### PR TITLE
feat: polling for transaction receipts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rif-marketplace-ui",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6258,11 +6258,11 @@
           }
         },
         "multicodec": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.1.tgz",
-          "integrity": "sha512-yrrU/K8zHyAH2B0slNVeq3AiwluflHpgQ3TAzwNJcuO2AoPyXgBT2EDkdbP1D8B/yFOY+S2hDYmFlI1vhVFkQw==",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.3.tgz",
+          "integrity": "sha512-8G4JKbHWSe/39Xx2uiI+/b/S6mGgimzwEN4TOCokFUIfofg1T8eHny88ht9eWImD2dng+EEQRsApXxA5ubhU4g==",
           "requires": {
-            "buffer": "^5.5.0",
+            "buffer": "^5.6.0",
             "varint": "^5.0.0"
           }
         }
@@ -19126,9 +19126,9 @@
       }
     },
     "multihashes": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.19.tgz",
-      "integrity": "sha512-ej74GAfA20imjj00RO5h34aY3pGUFyzn9FJZFWwdeUHlHTkKmv90FrNpvYT4jYf1XXCy5O/5EjVnxTaESgOM6A==",
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+      "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
       "requires": {
         "buffer": "^5.5.0",
         "multibase": "^0.7.0",
@@ -28439,15 +28439,6 @@
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
             "xhr-request-promise": "^0.1.2"
-          }
-        },
-        "ethereumjs-tx": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
-          "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
-          "requires": {
-            "ethereumjs-common": "^1.5.0",
-            "ethereumjs-util": "^6.0.0"
           }
         },
         "uuid": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "socket.io-client": "^2.3.0",
     "typescript": "^3.9.5",
     "web3": "^1.2.8",
+    "web3-eth": "^1.2.9",
     "web3-eth-contract": "^1.2.8",
     "web3-utils": "^1.2.8"
   },

--- a/src/components/pages/rns/buy/DomainOffersCheckoutPage.tsx
+++ b/src/components/pages/rns/buy/DomainOffersCheckoutPage.tsx
@@ -179,7 +179,7 @@ const DomainOffersCheckoutPage: FC<{}> = () => {
         const gasPrice = await web3.eth.getGasPrice()
 
         // Send Transfer and call transaction
-        const transferReceipt = await rifContract.transferAndCall(marketPlaceAddress, tokenPrice, tokenId, web3, { from: account, gasPrice })
+        const transferReceipt = await rifContract.transferAndCall(marketPlaceAddress, tokenPrice, tokenId, { from: account, gasPrice })
 
         if (!transferReceipt) {
           throw Error('Something unexpected happened. No receipt received from the transfer transaction.')

--- a/src/components/pages/rns/buy/DomainOffersCheckoutPage.tsx
+++ b/src/components/pages/rns/buy/DomainOffersCheckoutPage.tsx
@@ -18,8 +18,8 @@ import MarketStore from 'store/Market/MarketStore'
 import Logger from 'utils/Logger'
 import AddressItem from 'components/molecules/AddressItem'
 import contractAdds from 'ui-config.json'
-import getRifContract from 'contracts/Rif'
-import getMarketplaceContract from 'contracts/Marketplace'
+import RIFContract from 'contracts/Rif'
+import MarketplaceContract from 'contracts/Marketplace'
 import BlockchainStore from 'store/Blockchain/BlockchainStore'
 import { BLOCKCHAIN_ACTIONS } from 'store/Blockchain/blockchainActions'
 
@@ -72,7 +72,6 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
 
 const DomainOffersCheckoutPage: FC<{}> = () => {
   const classes = useStyles()
-
   const history = useHistory()
   const {
     state: {
@@ -102,11 +101,11 @@ const DomainOffersCheckoutPage: FC<{}> = () => {
   useEffect(() => {
     if (account && tokenId && !isFundsConfirmed) {
       const checkFunds = async () => {
-        const rifContract = getRifContract(web3)
-        const marketPlaceContract = getMarketplaceContract(web3)
+        const rifContract = RIFContract.getInstance(web3)
+        const marketPlaceContract = MarketplaceContract.getInstance(web3)
         try {
-          const myBalance = await rifContract.methods.balanceOf(account).call({ from: account })
-          const tokenPlacement = await marketPlaceContract.methods.placement(tokenId).call({ from: account })
+          const myBalance = await rifContract.getBalanceOf(account, { from: account })
+          const tokenPlacement = await marketPlaceContract.getPlacement(tokenId, { from: account })
           const price = tokenPlacement[1]
 
           setHasFunds(new web3.utils.BN(myBalance).gte(new web3.utils.BN(price)))
@@ -170,25 +169,20 @@ const DomainOffersCheckoutPage: FC<{}> = () => {
       })
 
       try {
-        const rifContract = getRifContract(web3)
-        const marketPlaceContract = getMarketplaceContract(web3)
+        const rifContract = RIFContract.getInstance(web3)
+        const marketPlaceContract = MarketplaceContract.getInstance(web3)
 
-        const tokenPlacement = await marketPlaceContract.methods.placement(tokenId).call({ from: account })
+        const tokenPlacement = await marketPlaceContract.getPlacement(tokenId, { from: account })
         const tokenPrice = tokenPlacement[1]
 
         // Get gas price
         const gasPrice = await web3.eth.getGasPrice()
 
-        // Get gas limit for Payment transaction
-        const estimatedGas = await rifContract.methods.transferAndCall(marketPlaceAddress, tokenPrice, tokenId).estimateGas({ from: account, gasPrice })
-        const gas = Math.floor(estimatedGas * 1.1)
-
-        // Payment transaction
-        const transferReceipt = await rifContract.methods.transferAndCall(marketPlaceAddress, tokenPrice, tokenId).send({ from: account, gas, gasPrice })
-        logger.info('transferReceipt:', transferReceipt)
+        // Send Transfer and call transaction
+        const transferReceipt = await rifContract.transferAndCall(marketPlaceAddress, tokenPrice, tokenId, web3, { from: account, gasPrice })
 
         if (!transferReceipt) {
-          throw Error('Something unexpected happened. No receipt received from the place transaction.')
+          throw Error('Something unexpected happened. No receipt received from the transfer transaction.')
         }
 
         bcDispatch({

--- a/src/components/pages/rns/cancel/CancelDomainCheckoutPage.tsx
+++ b/src/components/pages/rns/cancel/CancelDomainCheckoutPage.tsx
@@ -141,11 +141,11 @@ const CancelDomainCheckoutPage = () => {
         const gasPrice = await web3.eth.getGasPrice()
 
         // Send unapproval transaction
-        const unapproveReceipt = await rnsContract.approve('0x0000000000000000000000000000000000000000', tokenId, web3, { from: account, gasPrice })
+        const unapproveReceipt = await rnsContract.unapprove(tokenId, { from: account, gasPrice })
         logger.info('unapproveReceipt:', unapproveReceipt)
 
         // Send Unplacement transaction
-        const unplaceReceipt = await marketPlaceContract.unplace(tokenId, web3, { from: account, gasPrice })
+        const unplaceReceipt = await marketPlaceContract.unplace(tokenId, { from: account, gasPrice })
 
         if (!unplaceReceipt) {
           throw Error('Something unexpected happened. No receipt received from the unplace transaction.')

--- a/src/components/pages/rns/cancel/CancelDomainCheckoutPage.tsx
+++ b/src/components/pages/rns/cancel/CancelDomainCheckoutPage.tsx
@@ -14,8 +14,8 @@ import { MARKET_ACTIONS } from 'store/Market/marketActions'
 import MarketStore from 'store/Market/MarketStore'
 import Logger from 'utils/Logger'
 import AddressItem from 'components/molecules/AddressItem'
-import getMarketplaceContract from 'contracts/Marketplace'
-import getRnsContract from 'contracts/Rns'
+import MarketplaceContract from 'contracts/Marketplace'
+import RNSContract from 'contracts/Rns'
 import BlockchainStore from 'store/Blockchain/BlockchainStore'
 import { BLOCKCHAIN_ACTIONS } from 'store/Blockchain/blockchainActions'
 
@@ -134,32 +134,27 @@ const CancelDomainCheckoutPage = () => {
       })
 
       try {
-        const rnsContract = getRnsContract(web3)
-        const marketPlaceContract = getMarketplaceContract(web3)
+        const rnsContract = RNSContract.getInstance(web3)
+        const marketPlaceContract = MarketplaceContract.getInstance(web3)
 
         // Get gas price
         const gasPrice = await web3.eth.getGasPrice()
 
         // Send unapproval transaction
-        const unapproveReceipt = await rnsContract.methods.approve('0x0000000000000000000000000000000000000000', tokenId).send({ from: account, gasPrice })
+        const unapproveReceipt = await rnsContract.approve('0x0000000000000000000000000000000000000000', tokenId, web3, { from: account, gasPrice })
         logger.info('unapproveReceipt:', unapproveReceipt)
 
-        // Get gas limit for unplacement transaction
-        const estimatedGas = await marketPlaceContract.methods.unplace(tokenId).estimateGas({ from: account, gasPrice })
-        const gas = Math.floor(estimatedGas * 1.1)
+        // Send Unplacement transaction
+        const unplaceReceipt = await marketPlaceContract.unplace(tokenId, web3, { from: account, gasPrice })
 
-        // Send unplacement transaction
-        const receipt = await marketPlaceContract.methods.unplace(tokenId).send({ from: account, gas, gasPrice })
-        logger.info('unplace receipt:', receipt)
-
-        if (!receipt) {
-          throw Error('Something unexpected happened. No receipt received from the place transaction.')
+        if (!unplaceReceipt) {
+          throw Error('Something unexpected happened. No receipt received from the unplace transaction.')
         }
 
         bcDispatch({
           type: BLOCKCHAIN_ACTIONS.SET_TX_HASH,
           payload: {
-            txHash: receipt.transactionHash,
+            txHash: unplaceReceipt.transactionHash,
           } as any,
         })
         setIsPendingConfirm(true)

--- a/src/components/pages/rns/sell/DomainCheckoutPage.tsx
+++ b/src/components/pages/rns/sell/DomainCheckoutPage.tsx
@@ -145,11 +145,11 @@ const DomainsCheckoutPage: FC<{}> = () => {
         const gasPrice = await web3.eth.getGasPrice()
 
         // Send approval transaction
-        const approveReceipt = await rnsContract.approve(marketPlaceAddress, tokenId, web3, { from: account, gasPrice })
+        const approveReceipt = await rnsContract.approve(marketPlaceAddress, tokenId, { from: account, gasPrice })
         logger.info('approveReceipt:', approveReceipt)
 
         // Send Placement transaction
-        const placeReceipt = await marketPlaceContract.place(tokenId, rifTokenAddress, price, web3, { from: account, gasPrice })
+        const placeReceipt = await marketPlaceContract.place(tokenId, rifTokenAddress, price, { from: account, gasPrice })
 
         if (!placeReceipt) {
           throw Error('Something unexpected happened. No receipt received from the place transaction.')

--- a/src/components/pages/rns/sell/DomainCheckoutPage.tsx
+++ b/src/components/pages/rns/sell/DomainCheckoutPage.tsx
@@ -9,8 +9,8 @@ import AddressItem from 'components/molecules/AddressItem'
 import CombinedPriceCell from 'components/molecules/CombinedPriceCell'
 import TransactionInProgressPanel from 'components/organisms/TransactionInProgressPanel'
 import CheckoutPageTemplate from 'components/templates/CheckoutPageTemplate'
-import getMarketplaceContract from 'contracts/Marketplace'
-import getRnsContract from 'contracts/Rns'
+import MarketplaceContract from 'contracts/Marketplace'
+import RNSContract from 'contracts/Rns'
 import React, {
   FC, useContext, useEffect, useState,
 } from 'react'
@@ -138,32 +138,27 @@ const DomainsCheckoutPage: FC<{}> = () => {
       })
 
       try {
-        const rnsContract = getRnsContract(web3)
-        const marketPlaceContract = getMarketplaceContract(web3)
+        const rnsContract = RNSContract.getInstance(web3)
+        const marketPlaceContract = MarketplaceContract.getInstance(web3)
 
         // Get gas price
         const gasPrice = await web3.eth.getGasPrice()
 
         // Send approval transaction
-        const approveReceipt = await rnsContract.methods.approve(marketPlaceAddress, tokenId).send({ from: account })
-        logger.info('approveReciept:', approveReceipt)
-
-        // Get gas limit for Placement
-        const estimatedGas = await marketPlaceContract.methods.place(tokenId, rifTokenAddress, web3.utils.toWei(price)).estimateGas({ from: account, gasPrice })
-        const gas = Math.floor(estimatedGas * 1.1)
+        const approveReceipt = await rnsContract.approve(marketPlaceAddress, tokenId, web3, { from: account, gasPrice })
+        logger.info('approveReceipt:', approveReceipt)
 
         // Send Placement transaction
-        const receipt = await marketPlaceContract.methods.place(tokenId, rifTokenAddress, web3.utils.toWei(price)).send({ from: account, gas, gasPrice })
-        logger.info('place receipt:', receipt)
+        const placeReceipt = await marketPlaceContract.place(tokenId, rifTokenAddress, price, web3, { from: account, gasPrice })
 
-        if (!receipt) {
+        if (!placeReceipt) {
           throw Error('Something unexpected happened. No receipt received from the place transaction.')
         }
 
         bcDispatch({
           type: BLOCKCHAIN_ACTIONS.SET_TX_HASH,
           payload: {
-            txHash: receipt.transactionHash,
+            txHash: placeReceipt.transactionHash,
           } as any,
         })
         setIsPendingConfirm(true)

--- a/src/contracts/Marketplace.ts
+++ b/src/contracts/Marketplace.ts
@@ -2,14 +2,77 @@ import ERC721SimplePlacementsV1 from '@rsksmart/rif-marketplace-nfts/ERC721Simpl
 import Web3 from 'web3'
 import { Contract } from 'web3-eth-contract'
 import { AbiItem } from 'web3-utils'
+import { TransactionReceipt } from 'web3-eth'
 import contractAdds from 'ui-config.json'
+import waitForReceipt from './utils'
 
 const network: string = process.env.REACT_APP_NETWORK || 'ganache'
 const marketPlaceAddress = contractAdds[network].marketplace.toLowerCase()
 
-let contract: Contract | undefined
+class MarketplaceContract {
+  public static getInstance(web3: Web3): MarketplaceContract {
+    if (!MarketplaceContract.instance) {
+      MarketplaceContract.instance = new MarketplaceContract(web3)
+    }
+    return MarketplaceContract.instance
+  }
 
-export default (web3: Web3): Contract => {
-  if (!contract) contract = new web3.eth.Contract(ERC721SimplePlacementsV1.abi as AbiItem[], marketPlaceAddress)
-  return contract
+  private static instance: MarketplaceContract
+
+  private contract: Contract
+
+  private constructor(web3: Web3) {
+    this.contract = new web3.eth.Contract(ERC721SimplePlacementsV1.abi as AbiItem[], marketPlaceAddress)
+  }
+
+  // Place: Proxy function for placement transaction
+  public place = async (tokenId, rifTokenAddress, price, web3: Web3, txOptions): Promise<TransactionReceipt> => {
+    // Get gas limit for Placement
+    const estimatedGas = await this.contract.methods.place(tokenId, rifTokenAddress, web3.utils.toWei(price)).estimateGas({ from: txOptions.from, gasPrice: txOptions.gasPrice })
+    const gas = Math.floor(estimatedGas * 1.1)
+
+    // Placement Transaction
+    const placeReceipt = await new Promise<TransactionReceipt>((resolve, reject) => {
+      this.contract.methods.place(tokenId, rifTokenAddress, web3.utils.toWei(price)).send({ from: txOptions.from, gas, gasPrice: txOptions.gasPrice },
+        async (err, txHash) => {
+          if (err) return reject(err)
+          try {
+            const receipt = await waitForReceipt(txHash, web3)
+            return resolve(receipt)
+          } catch (e) {
+            return reject(new Error(e))
+          }
+        })
+    })
+    return placeReceipt
+  }
+
+  // Unplace: Proxy function for unplacement transaction
+  public unplace = async (tokenId, web3: Web3, txOptions): Promise<TransactionReceipt> => {
+    // Get gas limit for Unplacement
+    const estimatedGas = await this.contract.methods.unplace(tokenId).estimateGas({ from: txOptions.from, gasPrice: txOptions.gasPrice })
+    const gas = Math.floor(estimatedGas * 1.1)
+
+    // Unplacement Transaction
+    const unplaceReceipt = await new Promise<TransactionReceipt>((resolve, reject) => {
+      this.contract.methods.unplace(tokenId).send({ from: txOptions.from, gas, gasPrice: txOptions.gasPrice },
+        async (err, txHash) => {
+          if (err) return reject(err)
+          try {
+            const receipt = await waitForReceipt(txHash, web3)
+            return resolve(receipt)
+          } catch (e) {
+            return reject(new Error(e))
+          }
+        })
+    })
+    return unplaceReceipt
+  }
+
+  public getPlacement = async (tokenId, txOptions): Promise<Array<string | number>> => {
+    const placement = await this.contract.methods.placement(tokenId).call({ from: txOptions.from })
+    return placement
+  }
 }
+
+export default MarketplaceContract

--- a/src/contracts/Rif.ts
+++ b/src/contracts/Rif.ts
@@ -2,14 +2,55 @@ import ERC677 from '@rsksmart/erc677/ERC677Data.json'
 import Web3 from 'web3'
 import { Contract } from 'web3-eth-contract'
 import { AbiItem } from 'web3-utils'
+import { TransactionReceipt } from 'web3-eth'
 import contractAdds from 'ui-config.json'
+import waitForReceipt from './utils'
 
 const network: string = process.env.REACT_APP_NETWORK || 'ganache'
 const rifTokenAddress = contractAdds[network].rif.toLowerCase()
 
-let contract: Contract | undefined
+class RIFContract {
+  public static getInstance(web3: Web3): RIFContract {
+    if (!RIFContract.instance) {
+      RIFContract.instance = new RIFContract(web3)
+    }
+    return RIFContract.instance
+  }
 
-export default (web3: Web3): Contract => {
-  if (!contract) contract = new web3.eth.Contract(ERC677.abi as AbiItem[], rifTokenAddress)
-  return contract
+  private static instance: RIFContract
+
+  private contract: Contract
+
+  private constructor(web3: Web3) {
+    this.contract = new web3.eth.Contract(ERC677.abi as AbiItem[], rifTokenAddress)
+  }
+
+  public getBalanceOf = async (account, txOptions): Promise<number> => {
+    const balance = await this.contract.methods.balanceOf(account).call({ from: txOptions.from })
+    return balance
+  }
+
+  // Tramsfer And Call
+  public transferAndCall = async (contractAddress, tokenPrice, tokenId, web3: Web3, txOptions): Promise<TransactionReceipt> => {
+    // Get gas limit for Payment transaction
+    const estimatedGas = await this.contract.methods.transferAndCall(contractAddress, tokenPrice, tokenId).estimateGas({ from: txOptions.from, gasPrice: txOptions.gasPrice })
+    const gas = Math.floor(estimatedGas * 1.1)
+
+    // Transfer and Call transaction
+    const transferReceipt = await new Promise<TransactionReceipt>((resolve, reject) => {
+      this.contract.methods.transferAndCall(contractAddress, tokenPrice, tokenId).send({ from: txOptions.from, gas, gasPrice: txOptions.gasPrice },
+        async (err, txHash) => {
+          if (err) return reject(err)
+          try {
+            const receipt = await waitForReceipt(txHash, web3)
+            return resolve(receipt)
+          } catch (e) {
+            return reject(new Error(e))
+          }
+        })
+    })
+    return transferReceipt
+  }
 }
+
+export default RIFContract

--- a/src/contracts/Rif.ts
+++ b/src/contracts/Rif.ts
@@ -3,11 +3,8 @@ import Web3 from 'web3'
 import { Contract } from 'web3-eth-contract'
 import { AbiItem } from 'web3-utils'
 import { TransactionReceipt } from 'web3-eth'
-import contractAdds from 'ui-config.json'
-import waitForReceipt from './utils'
-
-const network: string = process.env.REACT_APP_NETWORK || 'ganache'
-const rifTokenAddress = contractAdds[network].rif.toLowerCase()
+import { rifTokenAddress } from './config'
+import waitForReceipt, { TransactionOptions } from './utils'
 
 class RIFContract {
   public static getInstance(web3: Web3): RIFContract {
@@ -21,31 +18,36 @@ class RIFContract {
 
   private contract: Contract
 
+  private web3: Web3
+
   private constructor(web3: Web3) {
     this.contract = new web3.eth.Contract(ERC677.abi as AbiItem[], rifTokenAddress)
+    this.web3 = web3
   }
 
-  public getBalanceOf = async (account, txOptions): Promise<number> => {
-    const balance = await this.contract.methods.balanceOf(account).call({ from: txOptions.from })
+  public getBalanceOf = (account: string, txOptions: TransactionOptions): Promise<number> => {
+    const { from } = txOptions
+    const balance = this.contract.methods.balanceOf(account).call({ from })
     return balance
   }
 
   // Tramsfer And Call
-  public transferAndCall = async (contractAddress, tokenPrice, tokenId, web3: Web3, txOptions): Promise<TransactionReceipt> => {
+  public transferAndCall = async (contractAddress: string, tokenPrice: string, tokenId: string, txOptions: TransactionOptions): Promise<TransactionReceipt> => {
     // Get gas limit for Payment transaction
-    const estimatedGas = await this.contract.methods.transferAndCall(contractAddress, tokenPrice, tokenId).estimateGas({ from: txOptions.from, gasPrice: txOptions.gasPrice })
+    const { from, gasPrice } = txOptions
+    const estimatedGas = await this.contract.methods.transferAndCall(contractAddress, tokenPrice, tokenId).estimateGas({ from, gasPrice })
     const gas = Math.floor(estimatedGas * 1.1)
 
     // Transfer and Call transaction
     const transferReceipt = await new Promise<TransactionReceipt>((resolve, reject) => {
-      this.contract.methods.transferAndCall(contractAddress, tokenPrice, tokenId).send({ from: txOptions.from, gas, gasPrice: txOptions.gasPrice },
+      this.contract.methods.transferAndCall(contractAddress, tokenPrice, tokenId).send({ from, gas, gasPrice },
         async (err, txHash) => {
           if (err) return reject(err)
           try {
-            const receipt = await waitForReceipt(txHash, web3)
+            const receipt = await waitForReceipt(txHash, this.web3)
             return resolve(receipt)
           } catch (e) {
-            return reject(new Error(e))
+            return reject(e)
           }
         })
     })

--- a/src/contracts/Rns.ts
+++ b/src/contracts/Rns.ts
@@ -2,14 +2,45 @@ import ERC721 from '@rsksmart/erc721/ERC721Data.json'
 import Web3 from 'web3'
 import { Contract } from 'web3-eth-contract'
 import { AbiItem } from 'web3-utils'
+import { TransactionReceipt } from 'web3-eth'
 import contractAdds from 'ui-config.json'
+import waitForReceipt from './utils'
 
 const network: string = process.env.REACT_APP_NETWORK || 'ganache'
 const rnsAddress = contractAdds[network].rnsDotRskOwner.toLowerCase()
 
-let contract: Contract | undefined
+class RNSContract {
+  public static getInstance(web3: Web3): RNSContract {
+    if (!RNSContract.instance) {
+      RNSContract.instance = new RNSContract(web3)
+    }
+    return RNSContract.instance
+  }
 
-export default (web3: Web3): Contract => {
-  if (!contract) contract = new web3.eth.Contract(ERC721.abi as AbiItem[], rnsAddress)
-  return contract
+  private static instance: RNSContract
+
+  private contract: Contract
+
+  private constructor(web3: Web3) {
+    this.contract = new web3.eth.Contract(ERC721.abi as AbiItem[], rnsAddress)
+  }
+
+  // approve: Token transfer approval
+  public approve = async (contractAddress, tokenId, web3: Web3, txOptions): Promise<TransactionReceipt> => {
+    const approveReceipt = await new Promise<TransactionReceipt>((resolve, reject) => {
+      this.contract.methods.approve(contractAddress, tokenId).send({ from: txOptions.from, gas: 100000, gasPrice: txOptions.gasPrice },
+        async (err, txHash) => {
+          if (err) return reject(err)
+          try {
+            const receipt = await waitForReceipt(txHash, web3)
+            return resolve(receipt)
+          } catch (e) {
+            return reject(new Error(e))
+          }
+        })
+    })
+    return approveReceipt
+  }
 }
+
+export default RNSContract

--- a/src/contracts/config.ts
+++ b/src/contracts/config.ts
@@ -1,0 +1,7 @@
+import contractAdds from 'ui-config.json'
+
+const network: string = process.env.REACT_APP_NETWORK || 'ganache'
+
+export const marketPlaceAddress = contractAdds[network].marketplace.toLowerCase()
+export const rifTokenAddress = contractAdds[network].rif.toLowerCase()
+export const rnsAddress = contractAdds[network].rnsDotRskOwner.toLowerCase()

--- a/src/contracts/utils.ts
+++ b/src/contracts/utils.ts
@@ -1,12 +1,20 @@
 import Web3 from 'web3'
 import { TransactionReceipt } from 'web3-eth'
 
-function waitForReceipt(txHash, web3: Web3) {
+export interface TransactionOptions {
+  from?: string
+  gas?: number
+  gasPrice?: string
+}
+
+const TIMEOUT_LIMIT = 120000
+const POLLING_INTERVAL = 2000
+
+function waitForReceipt(txHash: string, web3: Web3): Promise<TransactionReceipt> {
   let timeElapsed = 0
-  const interval = 2000
   return new Promise<TransactionReceipt>((resolve, reject) => {
     const checkInterval = setInterval(async () => {
-      timeElapsed += interval
+      timeElapsed += POLLING_INTERVAL
       const receipt = await web3.eth.getTransactionReceipt(txHash)
 
       if (receipt != null) {
@@ -14,10 +22,10 @@ function waitForReceipt(txHash, web3: Web3) {
         resolve(receipt)
       }
 
-      if (timeElapsed > 120000) {
+      if (timeElapsed > TIMEOUT_LIMIT) {
         reject(new Error('Transaction receipt could not be retrieved - Timeout'))
       }
-    }, interval)
+    }, POLLING_INTERVAL)
   })
 }
 

--- a/src/contracts/utils.ts
+++ b/src/contracts/utils.ts
@@ -1,0 +1,24 @@
+import Web3 from 'web3'
+import { TransactionReceipt } from 'web3-eth'
+
+function waitForReceipt(txHash, web3: Web3) {
+  let timeElapsed = 0
+  const interval = 2000
+  return new Promise<TransactionReceipt>((resolve, reject) => {
+    const checkInterval = setInterval(async () => {
+      timeElapsed += interval
+      const receipt = await web3.eth.getTransactionReceipt(txHash)
+
+      if (receipt != null) {
+        clearInterval(checkInterval)
+        resolve(receipt)
+      }
+
+      if (timeElapsed > 120000) {
+        reject(new Error('Transaction receipt could not be retrieved - Timeout'))
+      }
+    }, interval)
+  })
+}
+
+export default waitForReceipt


### PR DESCRIPTION
* Includes polling for `TransactionReceipt` in all transactions which is required for compatibility with Nifty wallet.
* Creates Singletons for each Contract (`Marketplace`, `Rif`, `Rns`) which implement proxy functions to avoid including transaction receipt logic on the pages.
* Saves the `web3` instance as attribute of the Contracts to avoid passing it every time.
* Creates a `utils.ts` file in the `/contracts` folder to avoid duplication of code.
* Creates a `config.ts` file to expose the Contract addresses.

Note: `Promise.race` did not help for polling the way we had to do, which is checking repeated times in certain intervals be which was our main requirement, so it was not used. It is helpful for setting up a Timeout so can be considered in other requirements.

Closes #215 
