### PR TITLE
Controls enabled services from the ui-config file

### DIFF
--- a/src/api/rif-marketplace-cache/rns/common.ts
+++ b/src/api/rif-marketplace-cache/rns/common.ts
@@ -1,20 +1,33 @@
 import { APIService } from 'api/models/apiService'
 import { RnsFilter } from 'api/models/RnsFilter'
 import network from 'blockchain/config'
-import { RnsDomain, RnsDomainOffer, RnsSoldDomain } from 'models/marketItems/DomainItem'
+import {
+  RnsDomain,
+  RnsDomainOffer,
+  RnsSoldDomain,
+} from 'models/marketItems/DomainItem'
 import { Modify } from 'utils/typeUtils'
 
 export type RnsAddresses = 'rns/v0/offers' | 'rns/v0/domains' | 'rns/v0/sold'
 export type RnsChannels = 'domains' | 'sold' | 'offers'
 
-export type RnsAPIService = Modify<APIService, {
-  path: RnsAddresses
-  _channel: RnsChannels
-  fetch: (filters: RnsFilter) => Promise<RnsDomain[] | RnsDomainOffer[] | RnsSoldDomain[]>
-}>
+export type RnsAPIService = Modify<
+  APIService,
+  {
+    path: RnsAddresses
+    _channel: RnsChannels
+    fetch: (
+      filters: RnsFilter
+    ) => Promise<RnsDomain[] | RnsDomainOffer[] | RnsSoldDomain[]>
+  }
+>
 
-export const getAvailableTokens = Object.keys(network.contractAddresses).reduce((acc, tokenSymbol) => {
-  const value = network.contractAddresses[tokenSymbol].toLowerCase()
-  acc[value] = tokenSymbol
-  return acc
-}, {})
+const { contractAddresses } = network
+export const getAvailableTokens = Object.keys(contractAddresses).reduce(
+  (acc, tokenSymbol) => {
+    const value = contractAddresses[tokenSymbol].toLowerCase()
+    acc[value] = tokenSymbol
+    return acc
+  },
+  {},
+)

--- a/src/api/rif-marketplace-cache/rns/common.ts
+++ b/src/api/rif-marketplace-cache/rns/common.ts
@@ -13,8 +13,8 @@ export type RnsAPIService = Modify<APIService, {
   fetch: (filters: RnsFilter) => Promise<RnsDomain[] | RnsDomainOffer[] | RnsSoldDomain[]>
 }>
 
-export const getAvailableTokens = Object.keys(network).reduce((acc, tokenSymbol) => {
-  const value = network[tokenSymbol].toLowerCase()
+export const getAvailableTokens = Object.keys(network.contractAddresses).reduce((acc, tokenSymbol) => {
+  const value = network.contractAddresses[tokenSymbol].toLowerCase()
   acc[value] = tokenSymbol
   return acc
 }, {})

--- a/src/components/Routes.tsx
+++ b/src/components/Routes.tsx
@@ -1,15 +1,14 @@
 import React, { useEffect } from 'react'
-import { Route, Switch, useHistory } from 'react-router-dom'
+import {
+  Route, Switch, useHistory,
+} from 'react-router-dom'
 import ROUTES from 'routes'
 import Logger from 'utils/Logger'
 import {
   AboutPage, FAQPage, LandingPage, NotFound,
 } from './pages'
-import {
-  DomainOffersCheckoutPage, DomainOffersPage, DomainsCheckoutPage,
-  SellDomainsListPage, DomainListed, DomainPurchased, CancelDomainCheckoutPage, DomainCanceled,
-} from './pages/rns'
 import StorageLandingPage from './pages/storage/StorageLandingPage'
+import RnsRoutes from './pages/rns/RnsRoutes'
 
 const logger = Logger.getInstance()
 
@@ -31,14 +30,7 @@ const Routes = () => {
       <Route exact path={ROUTES.LANDING} component={LandingPage} />
       <Route exact path={ROUTES.STORAGE} component={StorageLandingPage} />
       <Route exact path={ROUTES.FAQ} component={FAQPage} />
-      <Route exact path={ROUTES.DOMAINS.BUY} component={DomainOffersPage} />
-      <Route exact path={ROUTES.DOMAINS.CHECKOUT.BUY} component={DomainOffersCheckoutPage} />
-      <Route exact path={ROUTES.DOMAINS.DONE.BUY} component={DomainPurchased} />
-      <Route exact path={ROUTES.DOMAINS.SELL} component={SellDomainsListPage} />
-      <Route exact path={ROUTES.DOMAINS.CHECKOUT.SELL} component={DomainsCheckoutPage} />
-      <Route exact path={ROUTES.DOMAINS.DONE.SELL} component={DomainListed} />
-      <Route exact path={ROUTES.DOMAINS.CHECKOUT.CANCEL} component={CancelDomainCheckoutPage} />
-      <Route exact path={ROUTES.DOMAINS.DONE.CANCEL} component={DomainCanceled} />
+      <Route path={ROUTES.DOMAINS.BASE} component={RnsRoutes} />
       <Route exact path={ROUTES.ABOUT} component={AboutPage} />
       <Route component={NotFound} />
     </Switch>

--- a/src/components/Routes.tsx
+++ b/src/components/Routes.tsx
@@ -7,8 +7,8 @@ import Logger from 'utils/Logger'
 import {
   AboutPage, FAQPage, LandingPage, NotFound,
 } from './pages'
-import StorageLandingPage from './pages/storage/StorageLandingPage'
 import RnsRoutes from './pages/rns/RnsRoutes'
+import StorageRoutes from './pages/storage/StorageRoutes'
 
 const logger = Logger.getInstance()
 
@@ -28,7 +28,7 @@ const Routes = () => {
   return (
     <Switch>
       <Route exact path={ROUTES.LANDING} component={LandingPage} />
-      <Route exact path={ROUTES.STORAGE} component={StorageLandingPage} />
+      <Route exact path={ROUTES.STORAGE} component={StorageRoutes} />
       <Route exact path={ROUTES.FAQ} component={FAQPage} />
       <Route path={ROUTES.DOMAINS.BASE} component={RnsRoutes} />
       <Route exact path={ROUTES.ABOUT} component={AboutPage} />

--- a/src/components/Routes.tsx
+++ b/src/components/Routes.tsx
@@ -9,7 +9,7 @@ import {
   DomainOffersCheckoutPage, DomainOffersPage, DomainsCheckoutPage,
   SellDomainsListPage, DomainListed, DomainPurchased, CancelDomainCheckoutPage, DomainCanceled,
 } from './pages/rns'
-import StoragePage from './pages/storage/StoragePage'
+import StorageLandingPage from './pages/storage/StorageLandingPage'
 
 const logger = Logger.getInstance()
 
@@ -29,7 +29,7 @@ const Routes = () => {
   return (
     <Switch>
       <Route exact path={ROUTES.LANDING} component={LandingPage} />
-      <Route exact path={ROUTES.STORAGE} component={StoragePage} />
+      <Route exact path={ROUTES.STORAGE} component={StorageLandingPage} />
       <Route exact path={ROUTES.FAQ} component={FAQPage} />
       <Route exact path={ROUTES.DOMAINS.BUY} component={DomainOffersPage} />
       <Route exact path={ROUTES.DOMAINS.CHECKOUT.BUY} component={DomainOffersCheckoutPage} />

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -13,7 +13,8 @@ const Header = () => {
   const headerItems: HeaderItemProps[] = [
     {
       title: 'Domains',
-      to: ROUTES.DOMAINS.BUY,
+      to: ROUTES.DOMAINS.BASE,
+      // to: ROUTES.DOMAINS.BUY,
       isActive: (_, { pathname }) => pathname.includes(ROUTES.DOMAINS.BASE),
       icon: <PeopleIcon />,
     },

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -14,7 +14,6 @@ const Header = () => {
     {
       title: 'Domains',
       to: ROUTES.DOMAINS.BASE,
-      // to: ROUTES.DOMAINS.BUY,
       isActive: (_, { pathname }) => pathname.includes(ROUTES.DOMAINS.BASE),
       icon: <PeopleIcon />,
     },

--- a/src/components/pages/rns/RnsLandingPage.tsx
+++ b/src/components/pages/rns/RnsLandingPage.tsx
@@ -4,7 +4,7 @@ import SideImageTemplate from 'components/templates/SideImageTemplate'
 import Icon, { Icons } from 'components/atoms/Icon'
 
 const RnsLandingPage: FC<{}> = () => {
-  const domainsIcon = (<Icon src={Icons.DOMAINS} />)
+  const domainsIcon = <Icon src={Icons.DOMAINS} />
   const sideText = (
     <>
       <Typography variant="body1">
@@ -23,7 +23,7 @@ const RnsLandingPage: FC<{}> = () => {
       <br />
       <Typography variant="body1">
         You can now easily
-        <b>Buy and Sell RNS Domains</b>
+        <b> Buy and Sell RNS Domains</b>
         {' '}
         through the RIF Marketplace.
         <i>Sellers</i>
@@ -33,9 +33,9 @@ const RnsLandingPage: FC<{}> = () => {
         {' '}
         can browse the available Domains and purchase the one they prefer by paying the listed priced.
         To ensure transparency and provide security to all parties, the Marketplace acts as an
-        <b>escrow</b>
+        <b> escrow</b>
         , ensuring the Domain is released only when a
-        <b>valid payment</b>
+        <b> valid payment</b>
         {' '}
         is received. At no point in time the Marketplace owns or maintains your domain on hold. You will always have full control of your own Domains.
       </Typography>

--- a/src/components/pages/rns/RnsLandingPage.tsx
+++ b/src/components/pages/rns/RnsLandingPage.tsx
@@ -1,0 +1,49 @@
+import React, { FC } from 'react'
+import { Typography } from '@rsksmart/rif-ui'
+import SideImageTemplate from 'components/templates/SideImageTemplate'
+import Icon, { Icons } from 'components/atoms/Icon'
+
+const RnsLandingPage: FC<{}> = () => {
+  const domainsIcon = (<Icon src={Icons.DOMAINS} />)
+  const sideText = (
+    <>
+      <Typography variant="body1">
+        <b>RIF Name Service (RNS)</b>
+        {' '}
+        enables the use of human readable names for blockchain addresses helping users to receive transactions in personalized domains. New RNS Domains can be obtained through the RNS Manager (
+        <a href="https://manager.rns.rifos.org/">https://manager.rns.rifos.org/</a>
+        )
+      </Typography>
+      <br />
+      <Typography variant="body1">
+        <b>RNS domains</b>
+        {' '}
+        are seamlessly integrated across RIF Services (Payments, Storage, Communications, etc) and provide the first multi blockchain naming service available for all major blockchains such as Bitcoin, Ethereum and Litecoin among others. In addition, RNS is built on top of RSK, thus it inherits Bitcoin&apos;s decentralized nature and security.
+      </Typography>
+      <br />
+      <Typography variant="body1">
+        You can now easily
+        <b>Buy and Sell RNS Domains</b>
+        {' '}
+        through the RIF Marketplace.
+        <i>Sellers</i>
+        {' '}
+        can simply list their owned domains and set a listing price in RIF for each of them (additional payments such as R-BTC, DOC and RDOC will be added soon!).
+        <i>Buyers</i>
+        {' '}
+        can browse the available Domains and purchase the one they prefer by paying the listed priced.
+        To ensure transparency and provide security to all parties, the Marketplace acts as an
+        <b>escrow</b>
+        , ensuring the Domain is released only when a
+        <b>valid payment</b>
+        {' '}
+        is received. At no point in time the Marketplace owns or maintains your domain on hold. You will always have full control of your own Domains.
+      </Typography>
+    </>
+  )
+  return (
+    <SideImageTemplate mainTitle="Domains" sideIcon={domainsIcon} sideText={sideText} />
+  )
+}
+
+export default RnsLandingPage

--- a/src/components/pages/rns/RnsRoutes.tsx
+++ b/src/components/pages/rns/RnsRoutes.tsx
@@ -1,0 +1,42 @@
+import React, { FC } from 'react'
+import {
+  Switch, Route, Redirect,
+} from 'react-router-dom'
+import ROUTES from 'routes'
+import uiConfig from 'ui-config.json'
+import { NotFound } from '..'
+import {
+  DomainOffersCheckoutPage, DomainOffersPage, DomainsCheckoutPage,
+  SellDomainsListPage, DomainListed, DomainPurchased, CancelDomainCheckoutPage, DomainCanceled,
+} from './index'
+import RnsLandingPage from './RnsLandingPage'
+
+const RnsRoutes: FC<{}> = () => {
+  const { services } = uiConfig
+  const rnsEnabled = services && (services as string[]).indexOf('rns') !== -1
+
+  if (rnsEnabled) {
+    return (
+      <Switch>
+        <Redirect exact from={ROUTES.DOMAINS.BASE} to={ROUTES.DOMAINS.BUY} />
+        <Route exact path={ROUTES.DOMAINS.BUY} component={DomainOffersPage} />
+        <Route exact path={ROUTES.DOMAINS.CHECKOUT.BUY} component={DomainOffersCheckoutPage} />
+        <Route exact path={ROUTES.DOMAINS.DONE.BUY} component={DomainPurchased} />
+        <Route exact path={ROUTES.DOMAINS.SELL} component={SellDomainsListPage} />
+        <Route exact path={ROUTES.DOMAINS.CHECKOUT.SELL} component={DomainsCheckoutPage} />
+        <Route exact path={ROUTES.DOMAINS.DONE.SELL} component={DomainListed} />
+        <Route exact path={ROUTES.DOMAINS.CHECKOUT.CANCEL} component={CancelDomainCheckoutPage} />
+        <Route exact path={ROUTES.DOMAINS.DONE.CANCEL} component={DomainCanceled} />
+        <Route component={NotFound} />
+      </Switch>
+    )
+  }
+  return (
+    <Switch>
+      <Route exact path={ROUTES.DOMAINS.BASE} component={RnsLandingPage} />
+      <Redirect from="*" to={ROUTES.DOMAINS.BASE} />
+    </Switch>
+  )
+}
+
+export default RnsRoutes

--- a/src/components/pages/rns/RnsRoutes.tsx
+++ b/src/components/pages/rns/RnsRoutes.tsx
@@ -1,9 +1,9 @@
-import React, { FC } from 'react'
+import React from 'react'
 import {
   Switch, Route, Redirect,
 } from 'react-router-dom'
 import ROUTES from 'routes'
-import uiConfig from 'ui-config.json'
+import networkConfig from 'config'
 import { NotFound } from '..'
 import {
   DomainOffersCheckoutPage, DomainOffersPage, DomainsCheckoutPage,
@@ -11,11 +11,9 @@ import {
 } from './index'
 import RnsLandingPage from './RnsLandingPage'
 
-const RnsRoutes: FC<{}> = () => {
-  const network: string = process.env.REACT_APP_NETWORK || 'ganache'
-  const { services } = uiConfig[network]
-
-  const rnsEnabled = services && (services as string[]).indexOf('rns') !== -1
+const RnsRoutes = () => {
+  const { services } = networkConfig
+  const rnsEnabled = services && (services as string[]).includes('rns')
 
   if (rnsEnabled) {
     return (

--- a/src/components/pages/rns/RnsRoutes.tsx
+++ b/src/components/pages/rns/RnsRoutes.tsx
@@ -12,7 +12,9 @@ import {
 import RnsLandingPage from './RnsLandingPage'
 
 const RnsRoutes: FC<{}> = () => {
-  const { services } = uiConfig
+  const network: string = process.env.REACT_APP_NETWORK || 'ganache'
+  const { services } = uiConfig[network]
+
   const rnsEnabled = services && (services as string[]).indexOf('rns') !== -1
 
   if (rnsEnabled) {

--- a/src/components/pages/rns/buy/DomainOffersCheckoutPage.tsx
+++ b/src/components/pages/rns/buy/DomainOffersCheckoutPage.tsx
@@ -18,7 +18,6 @@ import { AddTxPayload } from 'store/Blockchain/blockchainActions'
 import BlockchainStore from 'store/Blockchain/BlockchainStore'
 import MarketStore from 'store/Market/MarketStore'
 import RnsOffersStore from 'store/Market/rns/OffersStore'
-import contractAdds from 'ui-config.json'
 import Logger from 'utils/Logger'
 
 import {
@@ -30,10 +29,9 @@ import {
 } from '@rsksmart/rif-ui'
 
 import { parseToBigDecimal } from 'utils/parsers'
+import { marketPlaceAddress } from 'contracts/config'
 
 const logger = Logger.getInstance()
-const network: string = process.env.REACT_APP_NETWORK || 'ganache'
-const marketPlaceAddress = contractAdds[network].marketplace.toLowerCase()
 
 const useStyles = makeStyles((theme: Theme) => createStyles({
   card: {

--- a/src/components/pages/rns/buy/DomainPurchased.tsx
+++ b/src/components/pages/rns/buy/DomainPurchased.tsx
@@ -5,10 +5,9 @@ import TxCompletePageTemplate from 'components/templates/TxCompletePageTemplate'
 import React, { FC } from 'react'
 import { useHistory } from 'react-router-dom'
 import ROUTES from 'routes'
-import uiConfig from 'ui-config.json'
+import networkConfig from 'config'
 
-const network: string = process.env.REACT_APP_NETWORK || 'ganache'
-const { rnsManagerUrl } = uiConfig[network]
+const { rnsManagerUrl } = networkConfig
 
 const useStyles = makeStyles((theme: Theme) => createStyles({
   actions: {

--- a/src/components/pages/rns/buy/DomainPurchased.tsx
+++ b/src/components/pages/rns/buy/DomainPurchased.tsx
@@ -5,10 +5,10 @@ import TxCompletePageTemplate from 'components/templates/TxCompletePageTemplate'
 import React, { FC } from 'react'
 import { useHistory } from 'react-router-dom'
 import ROUTES from 'routes'
-import networkConfig from 'ui-config.json'
+import uiConfig from 'ui-config.json'
 
 const network: string = process.env.REACT_APP_NETWORK || 'ganache'
-const { rnsManagerUrl } = networkConfig[network]
+const { rnsManagerUrl } = uiConfig[network]
 
 const useStyles = makeStyles((theme: Theme) => createStyles({
   actions: {

--- a/src/components/pages/rns/sell/DomainCheckoutPage.tsx
+++ b/src/components/pages/rns/sell/DomainCheckoutPage.tsx
@@ -21,17 +21,13 @@ import { AddTxPayload } from 'store/Blockchain/blockchainActions'
 import BlockchainStore from 'store/Blockchain/BlockchainStore'
 import MarketStore from 'store/Market/MarketStore'
 import RnsDomainsStore from 'store/Market/rns/DomainsStore'
-import contractAdds from 'ui-config.json'
 import Logger from 'utils/Logger'
 import AppStore, { AppStoreProps, errorReporterFactory } from 'store/App/AppStore'
 import { UIError } from 'models/UIMessage'
 import { LoadingPayload } from 'store/App/appActions'
+import { rifTokenAddress, marketPlaceAddress } from 'contracts/config'
 
 const logger = Logger.getInstance()
-
-const NETWORK: string = process.env.REACT_APP_NETWORK || 'ganache'
-const rifTokenAddress = contractAdds[NETWORK].rif.toLowerCase()
-const marketPlaceAddress = contractAdds[NETWORK].marketplace.toLowerCase()
 
 const useStyles = makeStyles((theme: Theme) => createStyles({
   card: {

--- a/src/components/pages/storage/StorageLandingPage.tsx
+++ b/src/components/pages/storage/StorageLandingPage.tsx
@@ -3,7 +3,7 @@ import { Typography } from '@rsksmart/rif-ui'
 import Icon, { Icons } from 'components/atoms/Icon'
 import SideImageTemplate from '../../templates/SideImageTemplate'
 
-const StoragePage: FC = () => {
+const StorageLandingPage: FC = () => {
   const storageIcon = (<Icon src={Icons.STORAGE} />)
   const sideText = (
     <>
@@ -59,4 +59,4 @@ const StoragePage: FC = () => {
   )
 }
 
-export default StoragePage
+export default StorageLandingPage

--- a/src/components/pages/storage/StorageRoutes.tsx
+++ b/src/components/pages/storage/StorageRoutes.tsx
@@ -1,0 +1,16 @@
+import React, { FC } from 'react'
+import {
+  Switch, Route,
+} from 'react-router-dom'
+import ROUTES from 'routes'
+import { NotFound } from '..'
+import StorageLandingPage from './StorageLandingPage'
+
+const StorageRoutes: FC<{}> = () => (
+  <Switch>
+    <Route exact path={ROUTES.STORAGE} component={StorageLandingPage} />
+    <Route component={NotFound} />
+  </Switch>
+)
+
+export default StorageRoutes

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,5 @@
+import uiConfig from 'ui-config.json'
+
+const network: string = process.env.REACT_APP_NETWORK || 'ganache'
+
+export default uiConfig[network]

--- a/src/contracts/config.ts
+++ b/src/contracts/config.ts
@@ -1,7 +1,8 @@
-import contractAdds from 'ui-config.json'
+import uiConfig from 'ui-config.json'
 
 const network: string = process.env.REACT_APP_NETWORK || 'ganache'
+const { contractAddresses } = uiConfig[network]
 
-export const marketPlaceAddress = contractAdds[network].marketplace.toLowerCase()
-export const rifTokenAddress = contractAdds[network].rif.toLowerCase()
-export const rnsAddress = contractAdds[network].rnsDotRskOwner.toLowerCase()
+export const marketPlaceAddress = contractAddresses.marketplace.toLowerCase()
+export const rifTokenAddress = contractAddresses.rif.toLowerCase()
+export const rnsAddress = contractAddresses.rnsDotRskOwner.toLowerCase()

--- a/src/contracts/config.ts
+++ b/src/contracts/config.ts
@@ -1,8 +1,9 @@
-import uiConfig from 'ui-config.json'
+import networkConfig from 'config'
 
-const network: string = process.env.REACT_APP_NETWORK || 'ganache'
-const { contractAddresses } = uiConfig[network]
+const {
+  contractAddresses: { marketplace, rif, rnsDotRskOwner },
+} = networkConfig
 
-export const marketPlaceAddress = contractAddresses.marketplace.toLowerCase()
-export const rifTokenAddress = contractAddresses.rif.toLowerCase()
-export const rnsAddress = contractAddresses.rnsDotRskOwner.toLowerCase()
+export const marketPlaceAddress = marketplace.toLowerCase()
+export const rifTokenAddress = rif.toLowerCase()
+export const rnsAddress = rnsDotRskOwner.toLowerCase()

--- a/src/ui-config.json
+++ b/src/ui-config.json
@@ -1,17 +1,25 @@
 {
     "ganache": {
-        "rif": "0x67B5656d60a809915323Bf2C40A8bEF15A152e3e",
-        "rnsDotRskOwner": "0x4bf749ec68270027C5910220CEAB30Cc284c7BA2",
-        "marketplace": "0xA29740dB2594af3786bc437Fc742Ae93e3Ec5B97",
-        "rnsManagerUrl": "http://localhost:3001"
+        "contractAddresses": {
+            "rif": "0x67B5656d60a809915323Bf2C40A8bEF15A152e3e",
+            "rnsDotRskOwner": "0x4bf749ec68270027C5910220CEAB30Cc284c7BA2",
+            "marketplace": "0x31630Dba815db73E9e0Fe16a4F42dF4bbFDB7Ba9"
+        },
+        "rnsManagerUrl": "http://localhost:3001",
+        "services": [
+            "rns",
+            "storage"
+        ]
     },
     "rsktestnet": {
-        "rif": "0x19f64674D8a5b4e652319F5e239EFd3bc969a1FE",
-        "rnsDotRskOwner": "0xca0a477e19bac7e0e172ccfd2e3c28a7200bdb71",
-        "marketplace": "0xA5c1afA6A7928aa017E800fB6B89f11219836C58",
-        "rnsManagerUrl": "https://testnet.manager.rns.rifos.org"
-    },
-    "services": [
-        "rns"
-    ]
+        "contractAddresses": {
+            "rif": "0x19f64674D8a5b4e652319F5e239EFd3bc969a1FE",
+            "rnsDotRskOwner": "0xca0a477e19bac7e0e172ccfd2e3c28a7200bdb71",
+            "marketplace": "0x5a2E616F64923AeF99E871EE6F80b9A00CCD6316"
+        },
+        "rnsManagerUrl": "https://testnet.manager.rns.rifos.org",
+        "services": [
+            "rns"
+        ]
+    }
 }

--- a/src/ui-config.json
+++ b/src/ui-config.json
@@ -10,5 +10,8 @@
         "rnsDotRskOwner": "0xca0a477e19bac7e0e172ccfd2e3c28a7200bdb71",
         "marketplace": "0xA5c1afA6A7928aa017E800fB6B89f11219836C58",
         "rnsManagerUrl": "https://testnet.manager.rns.rifos.org"
-    }
+    },
+    "services": [
+        "rns"
+    ]
 }


### PR DESCRIPTION
This PR closes #269 

Also grouped the addresses in the `ui-config` under a `contractAddresses` attribute and unified the way we were reading them as we had them exported in `src/contracts/config.ts`