### PR TITLE
fix: typo in pinner command

### DIFF
--- a/src/components/organisms/storage/sell/PinnerInstructionsModal.tsx
+++ b/src/components/organisms/storage/sell/PinnerInstructionsModal.tsx
@@ -29,7 +29,7 @@ const PinnerInstructionsModal: FC<PinnerInstructionsModal> = ({ open, onClose })
           className={classes.terminalInstructions}
         >
           <Grid item xs={12}>
-            <Typography align="center" color="secondary">$ npm install -g @rsksmart/rif-storage-pinner</Typography>
+            <Typography align="center" color="secondary">$ npm install -g @rsksmart/rif-storage-pinning</Typography>
           </Grid>
           <Grid item xs={12}>
             <Typography align="center" component="div" color="secondary">


### PR DESCRIPTION
* Fixes typo in pinner command from `pinner` to `pinning`