### PR TITLE
chore: updates rif-ui version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2729,9 +2729,9 @@
       }
     },
     "@rsksmart/rif-ui": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rif-ui/-/rif-ui-0.3.1.tgz",
-      "integrity": "sha512-0gunHGwQ7YlIYnO/vbjAQ32k0y6dcFbyNb23L/6FX9ClIADw+fgC3AVJXp/zof9ERABx44J2JumaLNJ4hpguXg=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rif-ui/-/rif-ui-0.3.2.tgz",
+      "integrity": "sha512-3iXhCpB3HX5GujbrYSmA+ctRjl7o2xqjPAO/3O1bqygsMleU9Xq/29MBXBRWb1aSgnI6/s0YnFMKbQCsmKbiBg=="
     },
     "@rsksmart/rns-auction-registrar": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@rsksmart/erc721": "^1.0.0",
     "@rsksmart/rif-marketplace-nfts": "^0.1.4",
     "@rsksmart/rif-marketplace-storage": "0.1.0-dev.5",
-    "@rsksmart/rif-ui": "^0.3.1",
+    "@rsksmart/rif-ui": "^0.3.2",
     "big.js": "^5.2.2",
     "material-ui-dropzone": "^3.5.0",
     "react": "^16.13.1",


### PR DESCRIPTION
Uses `rif-ui@v0.3.2` that has the spinner fixed