### PR TITLE
chore: updates rif-ui dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rif-marketplace-ui",
-  "version": "1.0.0",
+  "version": "1.1.0-dev.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2759,9 +2759,9 @@
       }
     },
     "@rsksmart/rif-ui": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rif-ui/-/rif-ui-0.4.0.tgz",
-      "integrity": "sha512-ayNHurCsSvFWLBTxixEeWLIyOsPkMjBQubBYeCv6oxPl4wWYGNh9lFcPhlRNt/+M9HAURnpQqglfRmi0aAFyCA=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rif-ui/-/rif-ui-0.4.1.tgz",
+      "integrity": "sha512-ef6nLts/BOzkUH89QKVacoMu/raaKyLM43bwrKt5aOX5Fobmi6ISlhb4aWr+5oVDoEJBuQs0vPWVQsS0crNaVg=="
     },
     "@rsksmart/rns-auction-registrar": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@rsksmart/erc721": "^1.0.0",
     "@rsksmart/rif-marketplace-nfts": "^0.1.4",
     "@rsksmart/rif-marketplace-storage": "0.1.0-dev.6",
-    "@rsksmart/rif-ui": "^0.4.0",
+    "@rsksmart/rif-ui": "^0.4.1",
     "big.js": "^6.0.2",
     "material-ui-dropzone": "^3.5.0",
     "react": "^16.13.1",


### PR DESCRIPTION
Closes #457. The Slider of the new version of `rif-ui` will trigger changes only on committed.