### PR TITLE
feat(storage): cleans up previous plans when creating offers & allows providers to see their inactive offers

### DIFF
--- a/src/api/models/storage/StorageFilter.ts
+++ b/src/api/models/storage/StorageFilter.ts
@@ -10,7 +10,7 @@ import { UNIT_PREFIX_POW2 } from 'utils/utils'
 export interface StorageFiltersTransport extends MarketFilter {
   averagePrice?: MinMaxFilter
   totalCapacity?: MinMaxFilter
-  periods: PeriodInSeconds[]
+  periods?: PeriodInSeconds[]
 }
 
 export const mapToTransport = ({
@@ -20,19 +20,28 @@ export const mapToTransport = ({
   provider,
   nonActive,
 }: StorageOffersFilters): StorageFiltersTransport => ({
-  periods: Array.from(periods).map(
-    (p: SubscriptionPeriod) => PeriodInSeconds[p],
-  ),
-  averagePrice: {
-    min: price.min - 1,
-    max: price.max + 1,
-  },
-  totalCapacity: {
-    min: sizeGB.min * UNIT_PREFIX_POW2.KILO,
-    max: sizeGB.max * UNIT_PREFIX_POW2.KILO,
-  },
   provider: {
     $like: provider,
   },
   'non-active': nonActive,
+  periods:
+    periods
+      ? Array.from(periods).map(
+        (p: SubscriptionPeriod) => PeriodInSeconds[p],
+      )
+      : undefined,
+  averagePrice:
+    price
+      ? {
+        min: price.min - 1,
+        max: price.max + 1,
+      }
+      : undefined,
+  totalCapacity:
+    sizeGB
+      ? {
+        min: sizeGB.min * UNIT_PREFIX_POW2.KILO,
+        max: sizeGB.max * UNIT_PREFIX_POW2.KILO,
+      }
+      : undefined,
 })

--- a/src/api/models/storage/StorageFilter.ts
+++ b/src/api/models/storage/StorageFilter.ts
@@ -18,6 +18,7 @@ export const mapToTransport = ({
   price,
   size: sizeGB,
   provider,
+  nonActive,
 }: StorageOffersFilters): StorageFiltersTransport => ({
   periods: Array.from(periods).map(
     (p: SubscriptionPeriod) => PeriodInSeconds[p],
@@ -33,4 +34,5 @@ export const mapToTransport = ({
   provider: {
     $like: provider,
   },
+  'non-active': nonActive,
 })

--- a/src/api/rif-marketplace-cache/storage/__tests__/offers.test.ts
+++ b/src/api/rif-marketplace-cache/storage/__tests__/offers.test.ts
@@ -92,6 +92,7 @@ describe('Storage OffersService', () => {
           utilizedCapacity, UNIT_PREFIX_POW2.KILO,
         ),
         totalCapacityGB: parseConvertBig(totalCapacity, UNIT_PREFIX_POW2.KILO),
+        isActive: true,
       }
 
       expect(actualReturnValue[0]).toStrictEqual(expectedOffers)

--- a/src/api/rif-marketplace-cache/storage/offers.ts
+++ b/src/api/rif-marketplace-cache/storage/offers.ts
@@ -56,6 +56,7 @@ const mapFromTransport = (offerTransport: OfferTransport): StorageOffer => {
     totalCapacityGB: parseConvertBig(
       totalCapacityMB, UNIT_PREFIX_POW2.KILO,
     ),
+    isActive: Number(totalCapacityMB) > 0,
   }
   return offer
 }

--- a/src/components/organisms/storage/myoffers/ExpandableOffer.tsx
+++ b/src/components/organisms/storage/myoffers/ExpandableOffer.tsx
@@ -136,7 +136,15 @@ const ExpandableOffer: FC<ExpandableOfferProps> = ({
             >
               Edit offer
             </Button>
-            <Button variant="outlined" rounded color="primary" onClick={handleCancelOpen}>Cancel offer</Button>
+            <Button
+              variant="outlined"
+              rounded
+              color="primary"
+              onClick={handleCancelOpen}
+              disabled={!storageOffer.isActive}
+            >
+              Cancel offer
+            </Button>
             <CancelOfferDialogue
               open={cancelOfferOpen}
               onClose={handleCancelClose}

--- a/src/models/marketItems/StorageFilters.ts
+++ b/src/models/marketItems/StorageFilters.ts
@@ -3,9 +3,9 @@ import { MinMaxFilter } from 'models/Filters'
 import { SubscriptionPeriod } from './StorageItem'
 
 export interface StorageOffersFilters extends MarketFilter {
-    price: MinMaxFilter
-    size: MinMaxFilter // total capacity. NOT available capacity!
-    periods: Set<SubscriptionPeriod>
+    price?: MinMaxFilter
+    size?: MinMaxFilter // total capacity. NOT available capacity!
+    periods?: Set<SubscriptionPeriod>
     provider?: string
     nonActive?: boolean
 }

--- a/src/models/marketItems/StorageFilters.ts
+++ b/src/models/marketItems/StorageFilters.ts
@@ -7,4 +7,5 @@ export interface StorageOffersFilters extends MarketFilter {
     size: MinMaxFilter // total capacity. NOT available capacity!
     periods: Set<SubscriptionPeriod>
     provider?: string
+    nonActive?: boolean
 }

--- a/src/models/marketItems/StorageItem.ts
+++ b/src/models/marketItems/StorageItem.ts
@@ -25,6 +25,7 @@ export interface StorageOffer extends Item {
   acceptedCurrencies: string[]
   peerId: string
   totalCapacityGB: Big
+  isActive: boolean
 }
 
 export type Agreement = Item & {


### PR DESCRIPTION
- makes all filters optional so we can just filter by provider no matter size or price
- when creating offers, cleans up billing plans if the provider had a previous offer (inactive or not) - Closes #477 
- allows providers to see their inactive offers - Closes #473 