### PR TITLE
fix(storage): lets user follow buy w no acc

### DIFF
--- a/src/components/pages/storage/buy/StorageOffersCheckoutPage.tsx
+++ b/src/components/pages/storage/buy/StorageOffersCheckoutPage.tsx
@@ -30,6 +30,7 @@ import WithLoginCard from 'components/hoc/WithLoginCard'
 import RoundBtn from 'components/atoms/RoundBtn'
 import { SupportedTokens } from 'contracts/interfaces'
 import { Web3Store } from '@rsksmart/rif-ui'
+import { SupportedTokens } from 'contracts/interfaces'
 
 const useStyles = makeStyles((theme: Theme) => ({
   stepperCard: {

--- a/src/components/pages/storage/buy/StorageOffersCheckoutPage.tsx
+++ b/src/components/pages/storage/buy/StorageOffersCheckoutPage.tsx
@@ -29,6 +29,7 @@ import { UNIT_PREFIX_POW2 } from 'utils/utils'
 import WithLoginCard from 'components/hoc/WithLoginCard'
 import RoundBtn from 'components/atoms/RoundBtn'
 import { SupportedTokens } from 'contracts/interfaces'
+import { Web3Store } from '@rsksmart/rif-ui'
 
 const useStyles = makeStyles((theme: Theme) => ({
   stepperCard: {
@@ -77,6 +78,13 @@ const StorageOffersCheckoutPage: FC = () => {
   } = useContext<ContextProps>(StorageCheckoutContext)
 
   const {
+    state: {
+      account,
+    },
+  } = useContext(Web3Store)
+
+  const {
+    id,
     token,
     total,
   } = order
@@ -90,7 +98,7 @@ const StorageOffersCheckoutPage: FC = () => {
 
   const changePlanHandle = ({
     target: { value },
-  }: React.ChangeEvent<{ name?: string, value: unknown}>): void => dispatch({
+  }: React.ChangeEvent<{ name?: string, value: unknown }>): void => dispatch({
     type: 'SET_AUXILIARY',
     payload: {
       selectedPlan: value as number,
@@ -196,17 +204,17 @@ const StorageOffersCheckoutPage: FC = () => {
         <GridColumn alignContent="center">
           <GridItem>
             {pinned && orderConfigTB && (
-            <StoragePurchaseCard
-              details={orderConfigTB}
-              submitProps={{
-                onClick: createAgreement,
-                children: 'Buy',
-              }}
-              title="Configuring storage plan"
-            />
+              <StoragePurchaseCard
+                details={orderConfigTB}
+                submitProps={{
+                  onClick: createAgreement,
+                  children: 'Buy',
+                }}
+                title="Configuring storage plan"
+              />
             )}
             {!pinned && (
-            <PinningCard dispatch={dispatch} />
+              <PinningCard dispatch={dispatch} />
             )}
           </GridItem>
         </GridColumn>
@@ -221,6 +229,20 @@ const StorageOffersCheckoutPage: FC = () => {
     ROUTES.STORAGE.BUY.BASE,
   )
 
+  if (id.toLowerCase() === account?.toLowerCase()) {
+    setTimeout(navToStorageBase, 3000)
+    return (
+      <CheckoutPageTemplate
+        className="storage-checkout-page"
+        backButtonProps={{
+          backTo: 'offers',
+        }}
+      >
+        You cannot buy your own storage. Redirecting to offers list...
+      </CheckoutPageTemplate>
+    )
+  }
+
   return (
     <CheckoutPageTemplate
       className="storage-checkout-page"
@@ -230,12 +252,17 @@ const StorageOffersCheckoutPage: FC = () => {
     >
       <GridColumn>
         <GridItem>
-          {order && pinned && <StorageOrderDescription order={{ ...order, ...pinned }} />}
+          {order && pinned
+            && (
+            <StorageOrderDescription
+              order={{ ...order, ...pinned }}
+            />
+            )}
         </GridItem>
         {/* STEPPER */}
-        { renderStepper() }
+        {renderStepper()}
         {/* CONTENT */}
-        { renderContent() }
+        {renderContent()}
       </GridColumn>
       <ProgressOverlay
         title="Creating agreement!"

--- a/src/components/pages/storage/buy/StorageOffersCheckoutPage.tsx
+++ b/src/components/pages/storage/buy/StorageOffersCheckoutPage.tsx
@@ -30,7 +30,6 @@ import WithLoginCard from 'components/hoc/WithLoginCard'
 import RoundBtn from 'components/atoms/RoundBtn'
 import { SupportedTokens } from 'contracts/interfaces'
 import { Web3Store } from '@rsksmart/rif-ui'
-import { SupportedTokens } from 'contracts/interfaces'
 
 const useStyles = makeStyles((theme: Theme) => ({
   stepperCard: {

--- a/src/components/pages/storage/buy/StorageOffersPage.tsx
+++ b/src/components/pages/storage/buy/StorageOffersPage.tsx
@@ -75,19 +75,20 @@ const StorageOffersPage: FC = () => {
         )).join(' - '),
         availableCurrencies: acceptedCurrencies.join(' - ').toUpperCase(),
         averagePrice: <ItemWUnit type="mediumPrimary" value={averagePrice.toString()} unit="USD" />,
-        action1: <SelectRowButton
-          id={id}
-          disabled={!account || isOwnAccount}
-          handleSelect={(): void => {
-            dispatch({
-              type: 'SET_ORDER',
-              payload: {
-                item,
-              } as OrderPayload,
-            })
-            history.push(ROUTES.STORAGE.BUY.CHECKOUT)
-          }}
-        />,
+        action1: isOwnAccount ? 'your offer' : (
+          <SelectRowButton
+            id={id}
+            handleSelect={(): void => {
+              dispatch({
+                type: 'SET_ORDER',
+                payload: {
+                  item,
+                } as OrderPayload,
+              })
+              history.push(ROUTES.STORAGE.BUY.CHECKOUT)
+            }}
+          />
+        ),
       }
     })
 


### PR DESCRIPTION
Users that didn't connect their wallet should be able to select a storage to purchase.

Resolves #495
Closes #446 