### PR TITLE
feat(storage): r excess /ipfs/ string from input

### DIFF
--- a/src/components/organisms/storage/buy/PinningCard.tsx
+++ b/src/components/organisms/storage/buy/PinningCard.tsx
@@ -171,7 +171,9 @@ const PinningCard: FC<Props> = ({ dispatch }) => {
             }}
             hash={{
               value: hash,
-              onChange: setInfoHandle(setHash),
+              onChange: ({ target: { value } }): void => {
+                setHash(value.replace(/^(\/*ipfs\/)/, ''))
+              },
               error: isHashEmpty || !isValidCID,
               InputProps: {
                 startAdornment: <InputAdornment position="start">{CID_PREFIX}</InputAdornment>,


### PR DESCRIPTION
Removes excess '/ipfs/' string from user input in the storage pinning view.

Resolves #496
Resolves [RMKT-427](https://rsklabs.atlassian.net/browse/RMKT-427)