### PR TITLE
fix(deps): reverts socket.io update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@babel/cli": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.12.7.tgz",
-      "integrity": "sha512-vE1fidQsaWnQVs4SItkuCdi3+uXqjbhw4cIKp8aawKxOnTnlvxYMzXSeMAqo6alldQRFQYb198YQfW0Sp1jl5Q==",
+      "version": "7.12.8",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.12.8.tgz",
+      "integrity": "sha512-/6nQj11oaGhLmZiuRUfxsujiPDc9BBReemiXgIbxc+M5W+MIiFKYwvNDJvBfnGKNsJTKbUfEheKc9cwoPHAVQA==",
       "dev": true,
       "requires": {
         "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents",
@@ -1269,9 +1269,9 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.7.tgz",
-      "integrity": "sha512-nMWaqsQEeSvMNypswUDzjqQ+0rR6pqCtoQpsqGJC4/Khm9cISwPTSpai57F6/jDaOoEGz8yE/WxcO3PV6tKSmQ==",
+      "version": "7.12.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.8.tgz",
+      "integrity": "sha512-EIRQXPTwFEGRZyu6gXbjfpNORN1oZvwuzJbxcXjAgWV0iqXYDszN1Hx3FVm6YgZfu1ZQbCVAk3l+nIw95Xll9Q==",
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/generator": "^7.12.5",
@@ -1712,9 +1712,9 @@
       }
     },
     "@ethersproject/abstract-provider": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.6.tgz",
-      "integrity": "sha512-3GJjD+wM8J160XFiTMkDu1UFV9uA1OdbMUI0aYy1CFepxYGSh9vY12bsbiYiTJLXQ86usvSBK6OA9U7IqmKZVw==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.7.tgz",
+      "integrity": "sha512-NF16JGn6M0zZP5ZS8KtDL2Rh7yHxZbUjBIHLNHMm/0X0BephhjUWy8jqs/Zks6kDJRzNthgmPVy41Ec0RYWPYA==",
       "requires": {
         "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
@@ -1726,9 +1726,9 @@
       }
     },
     "@ethersproject/abstract-signer": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.8.tgz",
-      "integrity": "sha512-Q5ZJtxs5txKBfTbdXRI4n6Nn4EJlKg3zA22S4Eg+P3hIZ+cXoLoK9CnA1GeKMRHJiDBqECnWqeQl+yyGR7D+jg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.9.tgz",
+      "integrity": "sha512-CM5UNmXQaA03MyYARFDDRjHWBxujO41tVle7glf5kHcQsDDULgqSVpkliLJMtPzZjOKFeCVZBHybTZDEZg5zzg==",
       "requires": {
         "@ethersproject/abstract-provider": "^5.0.4",
         "@ethersproject/bignumber": "^5.0.7",
@@ -1738,9 +1738,9 @@
       }
     },
     "@ethersproject/address": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.7.tgz",
-      "integrity": "sha512-+63DiYG+2og6rFNvQmLlLw8i5LtyT65n+jtHd06Ic81rLHc+JUKRpeZFhBa+gqh9f+P8V0xtKR5NI/EHXOfgSw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.8.tgz",
+      "integrity": "sha512-V87DHiZMZR6hmFYmoGaHex0D53UEbZpW75uj8AqPbjYUmi65RB4N2LPRcJXuWuN2R0Y2CxkvW6ArijWychr5FA==",
       "requires": {
         "@ethersproject/bignumber": "^5.0.10",
         "@ethersproject/bytes": "^5.0.4",
@@ -1750,17 +1750,17 @@
       }
     },
     "@ethersproject/base64": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.5.tgz",
-      "integrity": "sha512-4GJ9InM+zDDiiejPG/TrNGXVgD8D4BClEfJ3w45+ufyFA7QDT3gkAy+SdmmQCGAEBB+79MmXMLFq7TNtDM2DaA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.6.tgz",
+      "integrity": "sha512-HwrGn8YMiUf7bcdVvB4NJ+eWT0BtEFpDtrYxVXEbR7p/XBSJjwiR7DEggIiRvxbualMKg+EZijQWJ3az2li0uw==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4"
       }
     },
     "@ethersproject/bignumber": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.10.tgz",
-      "integrity": "sha512-1b3bMe+PCjx6xI5IINzaWtNZEKtwq2guVrhuwRqQmHEsAgKDK+UMckXYsu0CwMwRsQoeq+sNuCWd64pCxkBqMw==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.11.tgz",
+      "integrity": "sha512-6mS55WZDceEFZHaWKlRTKwOUmw8sU51Ar1Tbdt3qfk1HNf7i60d6MQVAWJswzCfKWx+E2gCBob8ywajgTZ7zMw==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
@@ -1768,25 +1768,25 @@
       }
     },
     "@ethersproject/bytes": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.6.tgz",
-      "integrity": "sha512-axEmVeVy5IS0Sg46fNk4mygMm96uGd/15b6zmMu53w0NpHmOC/GYfpqMBHYxavjFYN+LUL7vVwgpbIFYGO2QHA==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.7.tgz",
+      "integrity": "sha512-AxTEe6ucwifQiauelO/cpbm14coJTFPl/1uXTXclUO7zBy1HHpNRzspUZlJmozZ/vE6/yNsNq82vy+UmoTDF7g==",
       "requires": {
         "@ethersproject/logger": "^5.0.5"
       }
     },
     "@ethersproject/constants": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.6.tgz",
-      "integrity": "sha512-ioBMaUsVb2+C8UVAHUpfrrkNtFEcAYNaZSf79Lw7VhjFRY5f1ImWGqSZhJb4/wKxaw0RIYLW7ZriDgcx2YMwWA==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.7.tgz",
+      "integrity": "sha512-cbQK1UpE4hamB52Eg6DLhJoXeQ1plSzekh5Ujir1xdREdwdsZPPXKczkrWqBBR0KyywJZHN/o/hj0w8j7scSGg==",
       "requires": {
         "@ethersproject/bignumber": "^5.0.7"
       }
     },
     "@ethersproject/hash": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.7.tgz",
-      "integrity": "sha512-vYuRJRTAGHcYqQFAxxCgDpJtJv4aGC5TQm5NDZat/55BeLGLmH90ftJG1ldv7MhzGRxBPJtpqSHzJDizB6VKoA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.8.tgz",
+      "integrity": "sha512-Qay01tcFyFreYjSMt82rOQGMfQDmLm1sj3iNNO1BhrVf840xgBZuJ7gBATERzAjTuTCHUHw9BuGwxErJUS95yg==",
       "requires": {
         "@ethersproject/abstract-signer": "^5.0.6",
         "@ethersproject/address": "^5.0.5",
@@ -1799,48 +1799,48 @@
       }
     },
     "@ethersproject/keccak256": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.5.tgz",
-      "integrity": "sha512-9hXXp113jW5yPf27krofmnZ26u5SXsmuvrMTUuXyVdIDIJDLGorVyB2bBiWwENVok92E4WDnfAZHG+A+E6TCMQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.6.tgz",
+      "integrity": "sha512-eJ4Id/i2rwrf5JXEA7a12bG1phuxjj47mPZgDUbttuNBodhSuZF2nEO5QdpaRjmlphQ8Kt9PNqY/z7lhtJptZg==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "js-sha3": "0.5.7"
       }
     },
     "@ethersproject/logger": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.7.tgz",
-      "integrity": "sha512-1wl+kDTPdDptpQdrkTmImubygUf0mVeo0I/p8d21qdzT16h/GnoJWt7q6Kt0xvTfcI7Jv4kryskxI2xV++w5Hg=="
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
+      "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
     },
     "@ethersproject/networks": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.5.tgz",
-      "integrity": "sha512-DEcGEoRPtpbM+no9JmpwdCVVQELqYhP42BKArLsqps6nIEqOInWnjfpXfEss+nTrBp3zDrL4KNfOe7mS96C/mQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.6.tgz",
+      "integrity": "sha512-2Cg1N5109zzFOBfkyuPj+FfF7ioqAsRffmybJ2lrsiB5skphIAE72XNSCs4fqktlf+rwSh/5o/UXRjXxvSktZw==",
       "requires": {
         "@ethersproject/logger": "^5.0.5"
       }
     },
     "@ethersproject/properties": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.5.tgz",
-      "integrity": "sha512-2HwajwTUwlrOsiLVyyxiS4oP0a4xBNi1i90/kDJESmtlDmf2DkrY6qjBssa9YnWoEH34N/ZpLFVndimIrlo8kg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.6.tgz",
+      "integrity": "sha512-a9DUMizYhJ0TbtuDkO9iYlb2CDlpSKqGPDr+amvlZhRspQ6jbl5Eq8jfu4SCcGlcfaTbguJmqGnyOGn1EFt6xA==",
       "requires": {
         "@ethersproject/logger": "^5.0.5"
       }
     },
     "@ethersproject/rlp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.5.tgz",
-      "integrity": "sha512-RAUhk5+VH2UquTawgf7eK1i4Qbbzt0Ky6M27Q9JniRx0SBqmTkbKx/iXRZN/0x9vqQJhT596Z3vVevhqSa+GPQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.6.tgz",
+      "integrity": "sha512-M223MTaydfmQSsvqAl0FJZDYFlSqt6cgbhnssLDwqCKYegAHE16vrFyo+eiOapYlt32XAIJm0BXlqSunULzZuQ==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/logger": "^5.0.5"
       }
     },
     "@ethersproject/signing-key": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.6.tgz",
-      "integrity": "sha512-KjyePQsh+L6BwmPWD5JoXCrRGjNfYSD5YeXQhy6YWQeMAfG0+WMG7U2SKzl+DWM+8/Ymat3s6o3U2GLXhGrcMg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.7.tgz",
+      "integrity": "sha512-JYndnhFPKH0daPcIjyhi+GMcw3srIHkQ40hGRe6DA0CdGrpMfgyfSYDQ2D8HL2lgR+Xm4SHfEB0qba6+sCyrvg==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
@@ -1849,9 +1849,9 @@
       }
     },
     "@ethersproject/strings": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.6.tgz",
-      "integrity": "sha512-eJf0TKk/X2MvR3OSaOsS4XhKkWTi4p7YrZp2P1DaiTP+xsxizMYI1Ds5VUB4DH4RIseUe4Sbf6eN2dfG+fhW2w==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.7.tgz",
+      "integrity": "sha512-a+6T80LvmXGMOOWQTZHtGGQEg1z4v8rm8oX70KNs55YtPXI/5J3LBbVf5pyqCKSlmiBw5IaepPvs5XGalRUSZQ==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/constants": "^5.0.4",
@@ -1859,9 +1859,9 @@
       }
     },
     "@ethersproject/transactions": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.7.tgz",
-      "integrity": "sha512-U7dyBMQ73lHUoAnp3fdcfhgvJwcow88b0/q7Fl6Id21/Ll7Dxe7qrWjR6pH6XTKV+h2a74o/pJS7CxNiwahaHw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.8.tgz",
+      "integrity": "sha512-i7NtOXVzUe+YSU6QufzlRrI2WzHaTmULAKHJv4duIZMLqzehCBXGA9lTpFgFdqGYcQJ7vOtNFC2BB2mSjmuXqg==",
       "requires": {
         "@ethersproject/address": "^5.0.4",
         "@ethersproject/bignumber": "^5.0.7",
@@ -1875,9 +1875,9 @@
       }
     },
     "@ethersproject/web": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.10.tgz",
-      "integrity": "sha512-j49TbzUJBggILUuZahNXG59ugktjfCJyJfNhmC068DwIG0k+ygYK2BV1CWP3uuh7H2DHZ6LMLC+IsWWKb8MDlA==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.11.tgz",
+      "integrity": "sha512-x03ihbPoN1S8Gsh9WSwxkYxUIumLi02ZEKJku1C43sxBfe+mdprWyvujzYlpuoRNfWRgNhdRDKMP8JbG6MwNGA==",
       "requires": {
         "@ethersproject/base64": "^5.0.3",
         "@ethersproject/bytes": "^5.0.4",
@@ -3533,11 +3533,6 @@
         "@types/node": "*"
       }
     },
-    "@types/component-emitter": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
-      "integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg=="
-    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -4334,8 +4329,7 @@
     "after": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
-      "dev": true
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
     "agent-base": {
       "version": "6.0.2",
@@ -4762,8 +4756,7 @@
     "arraybuffer.slice": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
-      "dev": true
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
     },
     "arrify": {
       "version": "1.0.1",
@@ -5520,9 +5513,9 @@
       }
     },
     "base64-arraybuffer": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
-      "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI="
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
     },
     "base64-js": {
       "version": "1.5.1",
@@ -5552,7 +5545,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-      "dev": true,
       "requires": {
         "callsite": "1.0.0"
       }
@@ -5609,8 +5601,7 @@
     "blob": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
-      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
-      "dev": true
+      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
     },
     "bluebird": {
       "version": "3.7.2",
@@ -6302,8 +6293,7 @@
     "callsite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
-      "dev": true
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
     },
     "callsites": {
       "version": "2.0.0",
@@ -6362,9 +6352,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001159",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz",
-      "integrity": "sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA=="
+      "version": "1.0.30001161",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001161.tgz",
+      "integrity": "sha512-JharrCDxOqPLBULF9/SPa6yMcBRTjZARJ6sc3cuKrPfyIk64JN6kuMINWqA99Xc8uElMFcROliwtz0n9pYej+g=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -6908,8 +6898,7 @@
     "component-inherit": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
-      "dev": true
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
     },
     "compose-function": {
       "version": "3.0.3",
@@ -11125,9 +11114,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.604",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.604.tgz",
-      "integrity": "sha512-Mk5ODhvz+ZaQpVFXbu51wGW94P3CnkJIDkEQGxXMl6Ix6R0PG4IFWz83WbqFEZjN1UksoTsmmzKY5SmUrEvNJQ=="
+      "version": "1.3.606",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.606.tgz",
+      "integrity": "sha512-+/2yPHwtNf6NWKpaYt0KoqdSZ6Qddt6nDfH/pnhcrHq9hSb23e5LFy06Mlf0vF2ykXvj7avJ597psqcbKnG5YQ=="
     },
     "electron-window": {
       "version": "0.8.1",
@@ -11219,12 +11208,6 @@
         "ws": "~3.3.1"
       },
       "dependencies": {
-        "base64-arraybuffer": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-          "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
-          "dev": true
-        },
         "cookie": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
@@ -11262,41 +11245,74 @@
       }
     },
     "engine.io-client": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-4.0.4.tgz",
-      "integrity": "sha512-and4JRvjv+BQ4WBLopYUFePxju3ms3aBRk0XjaLdh/t9TKv2LCKtKKWFRoRzIfUZsu3U38FcYqNLuXhfS16vqw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.4.tgz",
+      "integrity": "sha512-iU4CRr38Fecj8HoZEnFtm2EiKGbYZcPn3cHxqNGl/tmdWRf60KhK+9vE0JeSjgnlS/0oynEfLgKbT9ALpim0sQ==",
       "requires": {
-        "base64-arraybuffer": "0.1.4",
         "component-emitter": "~1.3.0",
-        "debug": "~4.1.0",
-        "engine.io-parser": "~4.0.1",
+        "component-inherit": "0.0.3",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.2.0",
         "has-cors": "1.1.0",
+        "indexof": "0.0.1",
         "parseqs": "0.0.6",
         "parseuri": "0.0.6",
-        "ws": "~7.2.1",
+        "ws": "~6.1.0",
         "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.0.0"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "parseqs": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
+          "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w=="
+        },
+        "parseuri": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+          "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow=="
+        },
         "ws": {
-          "version": "7.2.5",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.5.tgz",
-          "integrity": "sha512-C34cIU4+DB2vMyAbmEKossWq2ZQDr6QEyuuCzWrM9zfw1sGc0mYiJ0UnG9zzNykt49C2Fi34hvr2vssFQRS6EA=="
+          "version": "6.1.4",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
+          "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
         }
       }
     },
     "engine.io-parser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.1.tgz",
-      "integrity": "sha512-v5aZK1hlckcJDGmHz3W8xvI3NUHYc9t8QtTbqdR5OaH3S9iJZilPubauOm+vLWOMMWzpE3hiq92l9lTAHamRCg=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
+      "integrity": "sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==",
+      "requires": {
+        "after": "0.8.2",
+        "arraybuffer.slice": "~0.0.7",
+        "base64-arraybuffer": "0.1.4",
+        "blob": "0.0.5",
+        "has-binary2": "~1.0.2"
+      },
+      "dependencies": {
+        "base64-arraybuffer": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+          "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI="
+        }
+      }
     },
     "enhanced-resolve": {
       "version": "3.4.1",
@@ -15446,7 +15462,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
       "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
-      "dev": true,
       "requires": {
         "isarray": "2.0.1"
       },
@@ -15454,8 +15469,7 @@
         "isarray": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
-          "dev": true
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
         }
       }
     },
@@ -16151,8 +16165,7 @@
     "indexof": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
-      "dev": true
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
     },
     "infer-owner": {
       "version": "1.0.4",
@@ -21316,8 +21329,7 @@
     "object-component": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
-      "dev": true
+      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -21927,14 +21939,20 @@
       "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
     },
     "parseqs": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
-      "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w=="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
     },
     "parseuri": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
-      "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow=="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
     },
     "parseurl": {
       "version": "1.3.3",
@@ -25809,12 +25827,6 @@
         "socket.io-parser": "~3.2.0"
       },
       "dependencies": {
-        "base64-arraybuffer": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-          "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
-          "dev": true
-        },
         "component-emitter": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -25874,24 +25886,6 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
-        "parseqs": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
-          "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-          "dev": true,
-          "requires": {
-            "better-assert": "~1.0.0"
-          }
-        },
-        "parseuri": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
-          "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-          "dev": true,
-          "requires": {
-            "better-assert": "~1.0.0"
-          }
-        },
         "socket.io-client": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
@@ -25934,20 +25928,31 @@
       "dev": true
     },
     "socket.io-client": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-3.0.3.tgz",
-      "integrity": "sha512-kwCJAKb6JMqE9ZYXg78Dgt8rYLSwtJ/g/LJqpb/pOTFRZMSr1cKAsCaisHZ+IBwKHBY7DYOOkjtkHqseY3ZLpw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz",
+      "integrity": "sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==",
       "requires": {
-        "@types/component-emitter": "^1.2.10",
         "backo2": "1.0.2",
+        "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
-        "component-emitter": "~1.3.0",
+        "component-emitter": "1.2.1",
         "debug": "~4.1.0",
-        "engine.io-client": "~4.0.0",
-        "parseuri": "0.0.6",
-        "socket.io-parser": "~4.0.1"
+        "engine.io-client": "~3.4.0",
+        "has-binary2": "~1.0.2",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "socket.io-parser": "~3.3.0",
+        "to-array": "0.1.4"
       },
       "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -25959,21 +25964,32 @@
       }
     },
     "socket.io-parser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.1.tgz",
-      "integrity": "sha512-5JfNykYptCwU2lkOI0ieoePWm+6stEhkZ2UnLDjqnE1YEjUlXXLd1lpxPZ+g+h3rtaytwWkWrLQCaJULlGqjOg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.1.tgz",
+      "integrity": "sha512-1QLvVAe8dTz+mKmZ07Swxt+LAo4Y1ff50rlyoEx00TQmDFVQYPfcqGvIDJLGaBdhdNCecXtyKpD+EgKGcmmbuQ==",
       "requires": {
         "component-emitter": "~1.3.0",
-        "debug": "~4.1.0"
+        "debug": "~3.1.0",
+        "isarray": "2.0.1"
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.0.0"
           }
+        },
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -28969,8 +28985,7 @@
     "to-array": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
-      "dev": true
+      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
     },
     "to-arraybuffer": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-dom": "17.0.1",
     "react-router-dom": "5.2.0",
     "react-scripts": "3.4.3",
-    "socket.io-client": "3.0.3",
+    "socket.io-client": "2.3.0",
     "typescript": "3.9.7",
     "web3": "1.3.0",
     "web3-eth": "1.3.0",


### PR DESCRIPTION
The socket.io v 3.0.3 update caused failure in the connection with the cache. This PR fixes that.