### PR TITLE
feat(storage): gets currency from plan transport

### DIFF
--- a/src/api/models/storage/transports.ts
+++ b/src/api/models/storage/transports.ts
@@ -2,9 +2,11 @@ export interface BillingPlanTransport {
   id: number
   period: string
   price: string
+  rateId: string
   offerId: string
   createdAt: string
   updatedAt: string
+  tokenAddress: string
 }
 
 export interface OfferTransport {

--- a/src/api/rif-marketplace-cache/storage/__tests__/offers.test.ts
+++ b/src/api/rif-marketplace-cache/storage/__tests__/offers.test.ts
@@ -28,6 +28,8 @@ const FAKE_OFFER_0: OfferTransport = {
       offerId: '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1',
       createdAt: '2020-08-10T14:11:32.680Z',
       updatedAt: '2020-08-10T14:11:32.680Z',
+      rateId: 'rif',
+      tokenAddress: 'FAKE_RIF_ADDRESS',
     },
   ],
 }
@@ -84,7 +86,7 @@ describe('Storage OffersService', () => {
           .map<BillingPlan>((plan) => ({
             period: PeriodInSeconds[plan.period],
             price: parseToBigDecimal(plan.price),
-            currency: SUPPORTED_TOKENS.rbtc,
+            currency: SUPPORTED_TOKENS.rif,
           })),
         averagePrice: avgBillingPrice,
         peerId: 'QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N',

--- a/src/api/rif-marketplace-cache/storage/agreements.ts
+++ b/src/api/rif-marketplace-cache/storage/agreements.ts
@@ -21,7 +21,7 @@ const getPaymentToken = (tokenAddress: string): SupportedTokens => {
   return Object
     .entries(availableTokens)
     .reduce(
-      (acc, [symbol, addr]) => (addr === tokenAddress ? symbol as SupportedTokens : acc),
+      (acc, [addr, symbol]) => (addr === tokenAddress ? symbol as SupportedTokens : acc),
           '' as SupportedTokens,
     )
 }
@@ -75,7 +75,7 @@ const mapFromTransport = ({
     size: contentSize,
     subscriptionPeriod: PeriodInSeconds[billingPeriod] as SubscriptionPeriod,
     title: '',
-    paymentToken: getPaymentToken(tokenAddress),
+    paymentToken: getPaymentToken(tokenAddress.toLowerCase()),
     consumer,
     withdrawableFunds,
     toBePayedOut: parseToBigDecimal(toBePayedOut, 18),

--- a/src/api/rif-marketplace-cache/storage/offers.ts
+++ b/src/api/rif-marketplace-cache/storage/offers.ts
@@ -41,11 +41,11 @@ const mapFromTransport = (offerTransport: OfferTransport): StorageOffer => {
           parseInt(a.period, 10) - parseInt(b.period, 10)
         ),
       )
-      .filter((plan) => !!PeriodInSeconds[plan.period])
+      .filter((plan) => Boolean(PeriodInSeconds[plan.period]))
       .map<BillingPlan>((plan) => ({
         period: PeriodInSeconds[plan.period],
         price: parseToBigDecimal(plan.price, 18),
-        currency: SUPPORTED_TOKENS.rbtc,
+        currency: SUPPORTED_TOKENS[plan.rateId],
       })),
     averagePrice: averagePriceTransport,
     acceptedCurrencies,

--- a/src/context/Services/storage/interfaces.ts
+++ b/src/context/Services/storage/interfaces.ts
@@ -1,8 +1,5 @@
-import { tokenDisplayNames } from 'api/rif-marketplace-cache/rates/xr'
-import networkConfig from 'config'
 import { StorageOffersFilters } from 'models/marketItems/StorageFilters'
 import { StorageItem, StorageOffer } from 'models/marketItems/StorageItem'
-import { ZERO_ADDRESS } from 'constants/strings'
 import { ContextState } from 'context/storeUtils/interfaces'
 import { Dispatch } from 'react'
 import { ServiceOrder, ServiceState } from '../interfaces'
@@ -23,10 +20,6 @@ export type StorageState = ServiceState<StorageItem> & {
 
 export type STORAGE_ACTION = OFFERS_ACTION
 
-export const TokenAddressees = {
-  [tokenDisplayNames.rbtc]: ZERO_ADDRESS, // we are using zero address for native token is Storage Manager SC
-  [tokenDisplayNames.rif]: networkConfig.contractAddresses.rif,
-}
 export type PinnedContent = {
   contentName: string
   contentSize: string

--- a/src/context/storage/buy/checkout/Context.tsx
+++ b/src/context/storage/buy/checkout/Context.tsx
@@ -2,7 +2,6 @@ import { Web3Store } from '@rsksmart/rif-ui'
 import { Big } from 'big.js'
 import AppContext, { AppContextProps, errorReporterFactory } from 'context/App/AppContext'
 import MarketContext, { MarketContextProps } from 'context/Market/MarketContext'
-import { TokenAddressees } from 'context/Services/storage/interfaces'
 import { StorageOffersContext } from 'context/Services/storage/offers'
 import createWithContext from 'context/storeUtils/createWithContext'
 import { BillingPlan, PeriodInSeconds, StorageOffer } from 'models/marketItems/StorageItem'
@@ -17,7 +16,7 @@ import Logger from 'utils/Logger'
 import { convertToWeiString } from 'utils/parsers'
 import { UNIT_PREFIX_POW2 } from 'utils/utils'
 import Web3 from 'web3'
-import { SUPPORTED_TOKENS, SupportedTokens } from 'contracts/interfaces'
+import { SUPPORTED_TOKENS, SupportedTokens, TxOptions } from 'contracts/interfaces'
 import { reducer } from './actions'
 import {
   AsyncActions, PinnedContent, Props, State,
@@ -157,8 +156,13 @@ const Provider: FC = ({ children }) => {
             .div(UNIT_PREFIX_POW2.MEGA)
             .round(0)
             .toString(),
-          token: TokenAddressees[token],
+          token: SUPPORTED_TOKENS[token],
         }
+        const txOptions: TxOptions = {
+          from: account,
+          token: SUPPORTED_TOKENS[token],
+        }
+
         const storageContract = (await import('contracts/storage'))
           .default
           .StorageContract
@@ -176,7 +180,7 @@ const Provider: FC = ({ children }) => {
           payload: { inProgress: true },
         })
         const receipt = await storageContract
-          .newAgreement(agreement, { from: account })
+          .newAgreement(agreement, txOptions)
           .catch((error) => {
             reportError(new UIError({
               error,


### PR DESCRIPTION
Adds the retrieval of the currency associated to a plan. The rest of the app has been designed anticipating this change, thus no other action needed.

~There is an issue with the rates for other currencies not showing, ie they show as 0, even thought the context (and indeed the component) observes the new rates. This however is not in the scope of this PR and will be handled as a separate issue (https://github.com/rsksmart/rif-marketplace-ui/issues/523).~

Resolves [RMKT-425](https://rsklabs.atlassian.net/browse/RMKT-425)
Resolves #501 