### PR TITLE
feat(storage-sell): pre-fills peerId from URL

### DIFF
--- a/src/components/organisms/storage/buy/PinningCard.tsx
+++ b/src/components/organisms/storage/buy/PinningCard.tsx
@@ -17,7 +17,7 @@ import { StorageCheckoutAction } from 'context/storage/buy/checkout'
 import { parseConvertBig } from 'utils/parsers'
 import { UNIT_PREFIX_POW2 } from 'utils/utils'
 import RoundBtn from 'components/atoms/RoundBtn'
-import { validateCID } from 'utils/stringUtils'
+import { validateCID } from 'utils/cidUtils'
 import StoragePinTabs from './StoragePinTabs'
 
 type Props = {

--- a/src/context/Market/storage/OfferEditContext.tsx
+++ b/src/context/Market/storage/OfferEditContext.tsx
@@ -1,7 +1,9 @@
-import React, { useReducer } from 'react'
+import React, { FC, useReducer } from 'react'
 import { ContextActions, ContextReducer } from 'context/storeUtils/interfaces'
 import storeReducerFactory from 'context/storeUtils/reducer'
 import { SubscriptionPeriod } from 'models/marketItems/StorageItem'
+import { useLocation } from 'react-router-dom'
+import { getURLParamByName, isEmpty } from 'utils/stringUtils'
 import { OfferEditState, OfferEditContextProps } from './interfaces'
 import { offerEditActions, OfferEditReducer } from './offerEditReducer'
 import { OfferEditPayload } from './offerEditActions'
@@ -26,7 +28,13 @@ export const initialState: OfferEditState = {
 const OfferEditContext = React.createContext({} as OfferEditContextProps | any)
 const offerEditReducer: OfferEditReducer<OfferEditPayload> | ContextReducer = storeReducerFactory(initialState, offerEditActions as unknown as ContextActions)
 
-export const OfferEditContextProvider = ({ children }) => {
+export const OfferEditContextProvider: FC = ({ children }) => {
+  const { search } = useLocation()
+
+  if (!isEmpty(search)) {
+    initialState.peerId = getURLParamByName(search, 'peerId') ?? initialState.peerId
+  }
+
   const [state, dispatch] = useReducer(offerEditReducer, initialState)
 
   const value = { state, dispatch }

--- a/src/utils/cidUtils.ts
+++ b/src/utils/cidUtils.ts
@@ -1,0 +1,19 @@
+import CID from 'cids'
+
+export const validateCID = (
+  cid: string,
+  errorHandle?: (e: Error) => unknown,
+): boolean => {
+  try {
+    CID.validateCID(new CID(cid))
+
+    return true
+  } catch (e) {
+    if (errorHandle) {
+      errorHandle(e)
+    }
+    return false
+  }
+}
+
+export default {}

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -19,3 +19,11 @@ export const validateCID = (
     return false
   }
 }
+
+export const getURLParamByName = (
+  url: string, param: string,
+): string | undefined => {
+  const rgx = `^(?:\\?*${param}=)(\\w*)`
+  const match = url.match(rgx)
+  return match?.find((_, i) => i === 1)
+}

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -1,25 +1,3 @@
-import CID from 'cids'
-
-export const isEmpty = (
-  text: string | unknown,
-): boolean => !text || !String(text).trim()
-
-export const validateCID = (
-  cid: string,
-  errorHandle?: (e: Error) => unknown,
-): boolean => {
-  try {
-    CID.validateCID(new CID(cid))
-
-    return true
-  } catch (e) {
-    if (errorHandle) {
-      errorHandle(e)
-    }
-    return false
-  }
-}
-
 export const getURLParamByName = (
   url: string, param: string,
 ): string | undefined => {
@@ -27,3 +5,7 @@ export const getURLParamByName = (
   const match = url.match(rgx)
   return match?.find((_, i) => i === 1)
 }
+
+export const isEmpty = (
+  text: string | unknown,
+): boolean => !(text && String(text).trim())


### PR DESCRIPTION
What the tin says.

Resolves [RMKT-402](https://rsklabs.atlassian.net/browse/RMKT-402)


Moved the cidValidation into its own utils file to prevent the CID TextDecoder issue when testing.