### PR TITLE
fix(storage): fixes offer creation

### DIFF
--- a/src/components/pages/storage/sell/StorageSellPage.tsx
+++ b/src/components/pages/storage/sell/StorageSellPage.tsx
@@ -93,17 +93,14 @@ const StorageSellPage: FC = () => {
       const currentOwnOffers = await storageOffersService.fetch({
         nonActive: true,
         provider: account,
-      })
-
-      const { subscriptionOptions } = currentOwnOffers
-        && currentOwnOffers[0] as StorageOffer
+      }) as StorageOffer[]
 
       setIsProcessing(true)
       const storageContract = StorageContract.getInstance(web3)
       const {
         totalCapacityMB, periods, prices, tokens,
       } = transformOfferDataForContract(
-        totalCapacity, billingPlans, subscriptionOptions,
+        totalCapacity, billingPlans, currentOwnOffers[0]?.subscriptionOptions,
       )
 
       const setOfferReceipt = await storageContract.setOffer(


### PR DESCRIPTION
It was failing when the user doesn't have any offer created yet, as `currentOwnOffers[0]` was `undefined` and so couldn't destructure `subscriptionOptions`