### PR TITLE
fix(general): rskjs-util library for checksum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25092,6 +25092,27 @@
         "bn.js": "^4.11.1"
       }
     },
+    "rskjs-util": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rskjs-util/-/rskjs-util-1.0.3.tgz",
+      "integrity": "sha512-Q6zfYFQndaBln1iY2gnBfYgDLymbZHAxKXOcZVLAKJkHilcieoUN3ZXVxLA3K30KlgAfmRVG72iTzi+yPNZB1w==",
+      "requires": {
+        "keccak": "^1.0.2"
+      },
+      "dependencies": {
+        "keccak": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "requires": {
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
+          }
+        }
+      }
+    },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react-dom": "17.0.1",
     "react-router-dom": "5.2.0",
     "react-scripts": "3.4.3",
+    "rskjs-util": "1.0.3",
     "socket.io-client": "2.3.0",
     "typescript": "3.9.7",
     "web3": "1.3.0",

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -1,6 +1,6 @@
 import { shortenString } from '@rsksmart/rif-ui'
 import { networkId } from 'config'
-import { toChecksumAddress } from 'web3-utils'
+import { toChecksumAddress } from 'rskjs-util'
 
 export const getURLParamByName = (
   url: string, param: string,


### PR DESCRIPTION
The web3 toChecksumAddress does not handle addresses beyond ethereum.