### PR TITLE
fix: removes precision from agreements available funds

### DIFF
--- a/src/components/organisms/storage/agreements/utils.tsx
+++ b/src/components/organisms/storage/agreements/utils.tsx
@@ -55,7 +55,7 @@ const getCoreItemFields = (
   )
   const feeValue = (
     <CombinedPriceCell
-      price={monthlyFee.toPrecision(2)}
+      price={monthlyFee.toString()}
       priceFiat={currency && monthlyFee.times(currency.rate).toPrecision(3)}
       currency={currency && currency.displayName}
       currencyFiat={currentFiat.displayName}


### PR DESCRIPTION
When combining RIF token and RBTC we had some issues displaying the amounts with `toPrecision(X)` so just showing the full amount until we design proper solution

**Before**
![Screen Shot 2020-11-27 at 13 22 46](https://user-images.githubusercontent.com/8449567/100476130-9286dd00-30c3-11eb-9ee2-2553382902f5.png)

**Now**
![Screen Shot 2020-11-27 at 13 23 16](https://user-images.githubusercontent.com/8449567/100476199-bea25e00-30c3-11eb-88c4-b916e7cfe7bc.png)
