### PR TITLE
refactor(storage): changes non-active to withInactive

### DIFF
--- a/src/api/models/storage/StorageFilter.ts
+++ b/src/api/models/storage/StorageFilter.ts
@@ -18,12 +18,12 @@ export const mapToTransport = ({
   price,
   size: sizeGB,
   provider,
-  nonActive,
+  withInactive,
 }: StorageOffersFilters): StorageFiltersTransport => ({
   provider: {
     $like: provider,
   },
-  'non-active': nonActive,
+  withInactive,
   periods:
     periods
       ? Array.from(periods).map(

--- a/src/components/organisms/storage/sell/OfferCreation.tsx
+++ b/src/components/organisms/storage/sell/OfferCreation.tsx
@@ -89,7 +89,7 @@ const OfferCreation: FC = () => {
       storageOffersService.connect(errorReporterFactory(appDispatch))
 
       const currentOwnOffers = await storageOffersService.fetch({
-        nonActive: true,
+        withInactive: true,
         provider: account,
       }) as StorageOffer[]
 

--- a/src/components/pages/storage/myoffers/StorageMyOffersPage.tsx
+++ b/src/components/pages/storage/myoffers/StorageMyOffersPage.tsx
@@ -60,7 +60,7 @@ const StorageMyOffersPage: FC = () => {
       storageOffersService.connect(errorReporterFactory(appDispatch))
 
       const currentOwnOffers = await storageOffersService.fetch({
-        nonActive: true,
+        withInactive: true,
         provider: account,
       }) as StorageOffer[]
 

--- a/src/models/marketItems/StorageFilters.ts
+++ b/src/models/marketItems/StorageFilters.ts
@@ -7,5 +7,5 @@ export interface StorageOffersFilters extends MarketFilter {
     size?: MinMaxFilter // total capacity. NOT available capacity!
     periods?: Set<SubscriptionPeriod>
     provider?: string
-    nonActive?: boolean
+    withInactive?: boolean
 }


### PR DESCRIPTION
Relates to cache https://github.com/rsksmart/rif-marketplace-cache/pull/432

Problem: word 'non-active' makes an awkward object key.