### PR TITLE
fix(storage-purchases): enables scroll view on purchases table

### DIFF
--- a/src/components/pages/storage/myPurchases/Page.tsx
+++ b/src/components/pages/storage/myPurchases/Page.tsx
@@ -28,6 +28,7 @@ import {
 import WithLoginCard from 'components/hoc/WithLoginCard'
 import ProgressOverlay from 'components/templates/ProgressOverlay'
 import withWithdrawContext, { StorageWithdrawContext, StorageWithdrawContextProps } from 'context/storage/mypurchases/withdraw'
+import GridRow from 'components/atoms/GridRow'
 
 const useTitleStyles = makeStyles(() => ({
   root: {
@@ -175,7 +176,7 @@ const MyStoragePurchases: FC = () => {
               Active contracts
             </Typography>
           </GridItem>
-          <GridItem>
+          <GridRow>
             <TableContainer>
               <Marketplace
                 headers={headers}
@@ -183,7 +184,7 @@ const MyStoragePurchases: FC = () => {
                 items={items}
               />
             </TableContainer>
-          </GridItem>
+          </GridRow>
         </GridColumn>
       </RoundedCard>
 


### PR DESCRIPTION
Closes #539 

<img width="1083" alt="Screen Shot 2020-12-08 at 13 23 05" src="https://user-images.githubusercontent.com/8449567/101510321-8c60ee00-3958-11eb-8688-472bef1c1e0e.png">
