### PR TITLE
fix(storage-buy): avoids reseting done status on success

### DIFF
--- a/src/context/storage/buy/checkout/Context.tsx
+++ b/src/context/storage/buy/checkout/Context.tsx
@@ -208,7 +208,6 @@ const Provider: FC = ({ children }) => {
             text: customMessage || 'Could not create new agreement.',
           }))
           Logger.getInstance().error('Error while creating new agreement: ', error)
-        } finally {
           dispatch({
             type: 'SET_STATUS',
             payload: {


### PR DESCRIPTION
I wrongly dispatched the `inProgress` status to `false` on the `finally` statement. It's reset when setting the status to `done`. By setting it again on the finally it resets the `isDone` prop and so the user is not able to see the thumbs up.