### PR TITLE
fix(contract-tokens): lowercases from address before sending tx

### DIFF
--- a/src/components/pages/storage/buy/StorageOffersPage.tsx
+++ b/src/components/pages/storage/buy/StorageOffersPage.tsx
@@ -63,7 +63,7 @@ const StorageOffersPage: FC = () => {
         subscriptionOptions, acceptedCurrencies,
       } = item
 
-      const isOwnAccount = account === id
+      const isOwnAccount = account?.toLowerCase() === id.toLowerCase()
 
       return {
         id,

--- a/src/contracts/wrappers/contract-using-tokens.ts
+++ b/src/contracts/wrappers/contract-using-tokens.ts
@@ -73,6 +73,8 @@ export class ContractWithTokens extends ContractBase {
   }
 
   async send(tx: any, txOptions: TxOptions): Promise<TransactionReceipt> {
+    // eslint-disable-next-line no-param-reassign
+    txOptions.from = txOptions.from?.toLowerCase()
     const { from, value } = txOptions
     const tokenToUse = this.getToken(txOptions.token)
 


### PR DESCRIPTION
Another option (perhaps cleaner) could be to make [TransactionOptions](https://github.com/rsksmart/rif-marketplace-ui/blob/master/src/contracts/interfaces.ts#L13) a class and lowercase the from attribute on the constructor