### PR TITLE
feat(confirmations): adds confirmations context

### DIFF
--- a/src/components/Market.tsx
+++ b/src/components/Market.tsx
@@ -8,6 +8,7 @@ import { NotificationsContextProvider } from 'context/Services/notifications'
 import React, { FC, useContext } from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import { makeStyles } from '@material-ui/core/styles'
+import { ConfirmationsContextProvider } from 'context/Confirmations'
 import Footer from './organisms/Footer'
 import Routes from './Routes'
 import AlertPanel from './organisms/AlertPanel'
@@ -58,6 +59,7 @@ const Market: FC = () => {
   }
 
   const orderedProviders = [
+    ConfirmationsContextProvider,
     NotificationsContextProvider,
     BlockchainContextProvider,
     MarketContextProvider,

--- a/src/components/molecules/InfoBar.tsx
+++ b/src/components/molecules/InfoBar.tsx
@@ -1,5 +1,5 @@
 import {
-  Button, ButtonProps, createStyles, makeStyles, Snackbar, Theme, Typography,
+  Button, ButtonProps, createStyles, makeStyles, Snackbar, Typography,
 } from '@material-ui/core'
 import MuiAlert from '@material-ui/lab/Alert'
 import { Severity } from 'models/UIMessage'
@@ -8,12 +8,12 @@ import React, { FC } from 'react'
 export interface InfoBarProps {
   isVisible: boolean
   text: string
-  button: ButtonProps
-  buttonText: string
+  button?: ButtonProps
+  buttonText?: string
   type: Severity
 }
 
-const useStyles = makeStyles((_: Theme) => createStyles({
+const useStyles = makeStyles(() => createStyles({
   alert: {
     alignItems: 'center',
     display: 'flex',
@@ -28,6 +28,7 @@ const InfoBar: FC<InfoBarProps> = ({
   isVisible, text, button, buttonText, type,
 }) => {
   const classes = useStyles()
+  const showButton = Boolean(button) && Boolean(buttonText)
 
   return (
     <Snackbar
@@ -36,7 +37,11 @@ const InfoBar: FC<InfoBarProps> = ({
     >
       <MuiAlert severity={type} className={classes.alert}>
         <Typography display="inline">{text}</Typography>
-        <Button className={classes.button} color="primary" {...button}>{buttonText}</Button>
+        {
+          showButton && (
+            <Button className={classes.button} color="primary" {...button}>{buttonText}</Button>
+          )
+        }
       </MuiAlert>
     </Snackbar>
   )

--- a/src/components/pages/storage/myPurchases/Page.tsx
+++ b/src/components/pages/storage/myPurchases/Page.tsx
@@ -31,6 +31,7 @@ import withWithdrawContext, { StorageWithdrawContext, StorageWithdrawContextProp
 import GridRow from 'components/atoms/GridRow'
 import { ConfirmationsContext, ConfirmationsContextProps } from 'context/Confirmations'
 import getConfirmationsFor from 'context/Confirmations/utils'
+import InfoBar from 'components/molecules/InfoBar'
 
 const useTitleStyles = makeStyles(() => ({
   root: {
@@ -179,10 +180,12 @@ const MyStoragePurchases: FC = () => {
       {
         Boolean(newAgreementsConfsCount)
         && (
-          <Typography>
-            {`Waiting confirmations for
-             ${newAgreementsConfsCount} new agreement(s)`}
-          </Typography>
+          <InfoBar
+            isVisible
+            type="info"
+            text={`Waiting confirmations for
+            ${newAgreementsConfsCount} new agreement(s)`}
+          />
         )
       }
       <RoundedCard color="secondary">

--- a/src/components/pages/storage/myPurchases/Page.tsx
+++ b/src/components/pages/storage/myPurchases/Page.tsx
@@ -29,6 +29,8 @@ import WithLoginCard from 'components/hoc/WithLoginCard'
 import ProgressOverlay from 'components/templates/ProgressOverlay'
 import withWithdrawContext, { StorageWithdrawContext, StorageWithdrawContextProps } from 'context/storage/mypurchases/withdraw'
 import GridRow from 'components/atoms/GridRow'
+import { ConfirmationsContext, ConfirmationsContextProps } from 'context/Confirmations'
+import getConfirmationsFor from 'context/Confirmations/utils'
 
 const useTitleStyles = makeStyles(() => ({
   root: {
@@ -70,6 +72,16 @@ const MyStoragePurchases: FC = () => {
       withdraw: withdrawAction,
     },
   } = useContext<StorageWithdrawContextProps>(StorageWithdrawContext)
+
+  const {
+    state: {
+      confirmations,
+    },
+  } = useContext<ConfirmationsContextProps>(ConfirmationsContext)
+
+  const newAgreementsConfsCount = getConfirmationsFor(
+    'AGREEMENT_NEW', confirmations,
+  ).length
 
   const [
     itemDetails,
@@ -164,6 +176,15 @@ const MyStoragePurchases: FC = () => {
 
   return (
     <CenteredPageTemplate>
+      {
+        Boolean(newAgreementsConfsCount)
+        && (
+          <Typography>
+            {`Waiting confirmations for
+             ${newAgreementsConfsCount} new agreement(s)`}
+          </Typography>
+        )
+      }
       <RoundedCard color="secondary">
         <GridColumn>
           <GridItem>

--- a/src/context/Confirmations/Context.tsx
+++ b/src/context/Confirmations/Context.tsx
@@ -1,0 +1,114 @@
+import { Web3Store } from '@rsksmart/rif-ui'
+import {
+  ConfirmationsService,
+  Transport as ConfirmationTransport,
+} from 'api/rif-marketplace-cache/blockchain/confirmations'
+import AppContext, { AppContextProps, errorReporterFactory } from 'context/App/AppContext'
+import { createReducer } from 'context/storeUtils/reducer'
+import React, {
+  createContext, FC, useContext, useEffect, useMemo, useReducer, useState,
+} from 'react'
+import Logger from 'utils/Logger'
+import actions from './actions'
+import { Props, State } from './interfaces'
+
+export const contextID = 'confirmations' as const
+export type ContextName = typeof contextID
+
+export const initialState: State = {
+  contextID,
+  txHashServiceMap: {
+    Agreements: undefined,
+    Staking: undefined,
+  },
+}
+
+export const Context = createContext<Props>({
+  state: initialState,
+  dispatch: () => undefined,
+})
+
+const logger = Logger.getInstance()
+
+export const Provider: FC = ({ children }) => {
+  const {
+    state: {
+      apis: {
+        confirmations: confirmationsApi,
+      },
+    },
+    dispatch: appDispatch,
+  } = useContext<AppContextProps>(AppContext)
+
+  const {
+    service,
+    connect,
+    attachEvent,
+    authenticate,
+  } = confirmationsApi as ConfirmationsService
+
+  const {
+    state: { account },
+  } = useContext(Web3Store)
+
+  const [state, dispatch] = useReducer(
+    createReducer(initialState, actions),
+    initialState,
+  )
+
+  const errorReporter = errorReporterFactory(appDispatch)
+  const [isInitialised, setIsInitialised] = useState(false)
+
+  // Get service connection
+  if (!service) {
+    connect(errorReporter)
+  }
+
+  const onConfirmationEvent = (event: ConfirmationTransport): void => { // type ConfirmationsTransport
+    logger.info('****************************************************************')
+    logger.info('new confirmation: ', { event })
+    logger.info('****************************************************************')
+  }
+
+  // Initialise
+  useEffect(() => {
+    if (service && !isInitialised && account) {
+      const initialise = async (): Promise<void> => {
+        try {
+          await authenticate(account)
+          attachEvent('newConfirmation', (event) => onConfirmationEvent(event))
+          setIsInitialised(true)
+        } catch (e) {
+          errorReporter({
+            error: e,
+            id: 'service-connection',
+            text: 'Error while initialising confirmations service.',
+          })
+          setIsInitialised(false)
+        }
+      }
+
+      initialise()
+    }
+  }, [
+    service,
+    authenticate,
+    attachEvent,
+    errorReporter,
+    isInitialised,
+    dispatch,
+    account,
+  ])
+
+  // Finalise
+  const value = useMemo(() => ({
+    state,
+    dispatch,
+  }), [state])
+
+  return (
+    <Context.Provider value={value}>
+      {children}
+    </Context.Provider>
+  )
+}

--- a/src/context/Confirmations/actions.ts
+++ b/src/context/Confirmations/actions.ts
@@ -1,0 +1,29 @@
+import Logger from 'utils/Logger'
+import { Actions } from './interfaces'
+
+const logger = Logger.getInstance()
+
+const actions: Actions = {
+  NEW_CONFIRMATION: (state, payload) => {
+    const {
+      transactionHash,
+      targetConfirmation,
+      confirmations,
+      event,
+    } = payload
+    const stateCopy = { ...state }
+    // TODO:
+    // - chequear si existe, si no crearla
+    // - si llega al target borrar el txHash del diccionario
+    // - chequear si conviene usar event as eventName para llevar mapeo de servicios que esperan confs, puede mejorar performance
+    logger.info('newConfirmation dispatched: ', { event })
+    stateCopy.txHashServiceMap[transactionHash] = {
+      ...state.txHashServiceMap[transactionHash],
+      currentCount: confirmations,
+      targetCount: targetConfirmation, // could be unnecessary if already set, but at the beginning it's needed
+    }
+    return stateCopy
+  },
+}
+
+export default actions

--- a/src/context/Confirmations/index.ts
+++ b/src/context/Confirmations/index.ts
@@ -1,0 +1,17 @@
+import {
+  Context,
+  Provider,
+  initialState,
+} from './Context'
+
+import {
+  Props, Action,
+} from './interfaces'
+
+export {
+  Context as ConfirmationsContext,
+  Provider as ConfirmationsContextProvider,
+  initialState as confirmationsInitialState,
+}
+export type ConfirmationsContextProps = Props
+export type ConfirmationsAction = Action

--- a/src/context/Confirmations/interfaces.ts
+++ b/src/context/Confirmations/interfaces.ts
@@ -1,0 +1,54 @@
+import { ContextState } from 'context/storeUtils/interfaces'
+import {
+  Transport as ConfirmationTransport,
+} from 'api/rif-marketplace-cache/blockchain/confirmations'
+import { Dispatch } from 'react'
+
+// TODO: put here all events refered to agreements so we only check that entry
+//  of the dictionary when an event of that type comes - will improve performance
+type AgreementsEvents = ''
+
+export type ServiceAwaiting = 'Agreements' | 'Staking'
+
+type ServiceConfirmations = {
+  txHash: string
+  currentCount: number
+  targetCount: number
+}
+
+type AgreementConfirmations = ServiceConfirmations & {
+  agreementId: string
+}
+
+type StakingConfirmations = ServiceConfirmations
+
+export type ServiceConfsMap = Record<
+  ServiceAwaiting,
+  undefined | AgreementConfirmations | StakingConfirmations
+>
+
+// STATE
+export type State = ContextState & {
+  txHashServiceMap: ServiceConfsMap
+}
+
+// PAYLOAD
+type NewConfirmationPayload = ConfirmationTransport
+
+// ACTIONS
+export type Action = (
+  | {
+    type: 'NEW_CONFIRMATION'
+    payload: NewConfirmationPayload
+  }
+)
+
+export type Actions = {
+  NEW_CONFIRMATION: (state: State, payload: NewConfirmationPayload) => State
+}
+
+// PROPS
+export type Props = {
+  state: State
+  dispatch: Dispatch<Action>
+}

--- a/src/context/Confirmations/interfaces.ts
+++ b/src/context/Confirmations/interfaces.ts
@@ -4,36 +4,53 @@ import {
 } from 'api/rif-marketplace-cache/blockchain/confirmations'
 import { Dispatch } from 'react'
 
-// TODO: put here all events refered to agreements so we only check that entry
-//  of the dictionary when an event of that type comes - will improve performance
-type AgreementsEvents = ''
+type AgreementContractAction = 'AGREEMENT_NEW' | 'AGREEMENT_WITHDRAW' | 'AGREEMENT_PAYOUT'
+type StakingContractAction = 'STAKING_STAKE' | 'STAKING_UNSTAKE'
 
-export type ServiceAwaiting = 'Agreements' | 'Staking'
+export type ContractAction =
+  | AgreementContractAction
+  | StakingContractAction
 
-type ServiceConfirmations = {
-  txHash: string
+export type AgreementWithdrawData = {
+  agreementReference: string
+}
+
+export type AgreementPayoutData = {
+  agreementReference: string
+}
+
+export type AgreementContractData =
+  | AgreementWithdrawData
+  | AgreementPayoutData
+
+export type ContractActionData =
+  | AgreementContractData
+
+export type TxHash = string
+
+export type ConfirmationData = {
+  contractAction: ContractAction
   currentCount: number
-  targetCount: number
+  targetCount?: number
+  contractActionData?: ContractActionData
 }
 
-type AgreementConfirmations = ServiceConfirmations & {
-  agreementId: string
-}
-
-type StakingConfirmations = ServiceConfirmations
-
-export type ServiceConfsMap = Record<
-  ServiceAwaiting,
-  undefined | AgreementConfirmations | StakingConfirmations
+export type ConfirmationsRecord = Record<
+  TxHash, ConfirmationData
 >
 
 // STATE
 export type State = ContextState & {
-  txHashServiceMap: ServiceConfsMap
+  confirmations: ConfirmationsRecord
 }
 
 // PAYLOAD
-type NewConfirmationPayload = ConfirmationTransport
+export type NewConfirmationPayload = ConfirmationTransport
+export type NewRequestPayload = {
+  txHash: string
+  contractAction: ContractAction
+  contractActionData?: ContractActionData
+}
 
 // ACTIONS
 export type Action = (
@@ -41,10 +58,15 @@ export type Action = (
     type: 'NEW_CONFIRMATION'
     payload: NewConfirmationPayload
   }
+  | {
+    type: 'NEW_REQUEST'
+    payload: NewRequestPayload
+  }
 )
 
 export type Actions = {
   NEW_CONFIRMATION: (state: State, payload: NewConfirmationPayload) => State
+  NEW_REQUEST: (state: State, payload: NewRequestPayload) => State
 }
 
 // PROPS

--- a/src/context/Confirmations/utils.ts
+++ b/src/context/Confirmations/utils.ts
@@ -1,0 +1,21 @@
+import {
+  ConfirmationsRecord, ContractAction, ConfirmationData,
+} from './interfaces'
+
+type GetConfirmationsFor = (
+  contractAction: ContractAction,
+  confirmations: ConfirmationsRecord
+) => ConfirmationData[]
+
+const getConfirmationsFor: GetConfirmationsFor = (
+  contractAction,
+  confirmations,
+) => (
+  Object.values(confirmations).filter(
+    ({
+      contractAction: confContractAction,
+    }) => confContractAction === contractAction,
+  )
+)
+
+export default getConfirmationsFor

--- a/src/context/storage/buy/checkout/Context.tsx
+++ b/src/context/storage/buy/checkout/Context.tsx
@@ -17,6 +17,7 @@ import { convertToWeiString } from 'utils/parsers'
 import { UNIT_PREFIX_POW2 } from 'utils/utils'
 import Web3 from 'web3'
 import { SUPPORTED_TOKENS, SupportedTokens, TxOptions } from 'contracts/interfaces'
+import { ConfirmationsContext, ConfirmationsContextProps } from 'context/Confirmations'
 import { reducer } from './actions'
 import {
   AsyncActions, PinnedContent, Props, State,
@@ -84,6 +85,10 @@ const Provider: FC = ({ children }) => {
       order: listedOffer,
     },
   } = useContext(StorageOffersContext)
+
+  const {
+    dispatch: confirmationsDispatch,
+  } = useContext<ConfirmationsContextProps>(ConfirmationsContext)
   const listedItem: StorageOffer | undefined = listedOffer?.item
 
   const [isInitialised, setIsInitialised] = useState(false)
@@ -193,6 +198,13 @@ const Provider: FC = ({ children }) => {
           if (!receipt) {
             throw new Error('Did not receive the recipt from the storage contract.')
           }
+          confirmationsDispatch({
+            type: 'NEW_REQUEST',
+            payload: {
+              contractAction: 'AGREEMENT_NEW',
+              txHash: receipt.transactionHash,
+            },
+          })
           dispatch({
             type: 'SET_STATUS',
             payload: {
@@ -218,7 +230,10 @@ const Provider: FC = ({ children }) => {
       }
       setAsyncActions({ createAgreement })
     }
-  }, [web3, account, appDispatch, history, order, pinned, reportError])
+  }, [
+    web3, account, appDispatch, history, order, pinned, reportError,
+    confirmationsDispatch,
+  ])
 
   // Sets plans and currency related states
   useEffect(() => {

--- a/src/context/storeUtils/interfaces.ts
+++ b/src/context/storeUtils/interfaces.ts
@@ -5,6 +5,7 @@ import { ContextName as AppContextName } from 'context/App/AppContext'
 import { ContextName as StorageEditOfferContextName } from 'context/Market/storage/OfferEditContext'
 import { ContextName as NotificationsContextName } from 'context/Services/notifications/interfaces'
 import { ContextName as StorageUploadContextName } from 'context/Services/storage/upload/Context'
+import { ContextName as ConfirmationsContextName } from 'context/Confirmations/Context'
 import { MARKET_ACTION } from 'context/Market/marketActions'
 import { APP_ACTION } from 'context/App/appActions'
 import { BLOCKCHAIN_ACTION } from 'context/Blockchain/blockchainActions'
@@ -22,6 +23,7 @@ export type AvailableContexts =
   | StorageEditOfferContextName
   | NotificationsContextName
   | StorageUploadContextName
+  | ConfirmationsContextName
 
 export interface ContextPayload {
   [key: string]: any // TODO: make into [K in keyof T]: any where T is ContextState
@@ -37,7 +39,7 @@ export type ContextActionType =
 export interface ContextDispatch<
   T extends ContextActionType,
   P extends ContextPayload
-> {
+  > {
   readonly type: T
   readonly payload: P
 }


### PR DESCRIPTION
`BlockchainContext` and `ConfirmationsContext` should be the same, but for the matter of transition I've created `ConfirmationsContext` to handle confirmations in a new way without interfering with `BlockchainContext` that's being used in many other services. 

Will close #586 

Will add https://github.com/rsksmart/rif-marketplace-ui/issues/607