### PR TITLE
feat(storage-agreements): handles renew confirmations

### DIFF
--- a/src/components/organisms/storage/agreements/utils.tsx
+++ b/src/components/organisms/storage/agreements/utils.tsx
@@ -9,7 +9,7 @@ import { MarketplaceItem } from 'components/templates/marketplace/Marketplace'
 import { tokenDisplayNames } from 'api/rif-marketplace-cache/rates/xr'
 import { getShortDateString } from 'utils/dateUtils'
 import { Spinner } from '@rsksmart/rif-ui'
-import { AgreementWithdrawData, ConfirmationData } from 'context/Confirmations/interfaces'
+import { AgreementUpdateData, ConfirmationData } from 'context/Confirmations/interfaces'
 
 export type AgreementView = {
   title: JSX.Element
@@ -114,16 +114,16 @@ export const createCustomerItemFields = (
     agreementView: (AgreementCustomerView),
     agreement: Agreement
   ) => void,
-  withdrawConfirmations: ConfirmationData[],
+  withdrawAndRenewConfs: ConfirmationData[],
 ): MarketplaceItem[] => agreements.map((agreement: Agreement) => {
   const {
     id, expiresInSeconds, isActive,
   } = agreement
   const customerView = getCustomerViewFrom(agreement, crypto, currentFiat)
 
-  const isProcessingWithdrawConfs = withdrawConfirmations.some(
+  const isProcessingConfs = withdrawAndRenewConfs.some(
     ({ contractActionData }) => (
-      (contractActionData as AgreementWithdrawData).agreementId === id
+      (contractActionData as AgreementUpdateData).agreementId === id
     ),
   )
 
@@ -136,7 +136,7 @@ export const createCustomerItemFields = (
     subscriptionPeriod: customerView['SUBSCRIPTION PERIOD'],
     monthlyFee: customerView['PRICE/GB'],
     withdrawableFunds: customerView['WITHDRAWABLE FUNDS'],
-    renew: isProcessingWithdrawConfs
+    renew: isProcessingConfs
       ? <Spinner />
       : (
         <SelectRowButton
@@ -149,7 +149,7 @@ export const createCustomerItemFields = (
           Renew
         </SelectRowButton>
       ),
-    view: isProcessingWithdrawConfs
+    view: isProcessingConfs
       ? <></>
       : (
         <SelectRowButton

--- a/src/components/organisms/storage/mypurchases/PurchasesTable.tsx
+++ b/src/components/organisms/storage/mypurchases/PurchasesTable.tsx
@@ -83,8 +83,8 @@ const PurchasesTable: FC<PurchasesProps> = (
     )
   }
 
-  const withdrawConfirmations = getConfirmationsFor(
-    'AGREEMENT_WITHDRAW', confirmations,
+  const withdrawAndRenewConfs = getConfirmationsFor(
+    ['AGREEMENT_WITHDRAW', 'AGREEMENT_RENEW'], confirmations,
   )
 
   const headers = {
@@ -112,7 +112,7 @@ const PurchasesTable: FC<PurchasesProps> = (
         payload: agreement,
       })
     },
-    withdrawConfirmations,
+    withdrawAndRenewConfs,
   )
 
   const modalActions = (): JSX.Element => {

--- a/src/components/pages/storage/myPurchases/Page.tsx
+++ b/src/components/pages/storage/myPurchases/Page.tsx
@@ -57,7 +57,7 @@ const MyStoragePurchases: FC = () => {
   } = useContext<ConfirmationsContextProps>(ConfirmationsContext)
 
   const newAgreementsConfsCount = getConfirmationsFor(
-    'AGREEMENT_NEW', confirmations,
+    ['AGREEMENT_NEW'], confirmations,
   ).length
 
   // filters agreements by current account

--- a/src/context/Confirmations/interfaces.ts
+++ b/src/context/Confirmations/interfaces.ts
@@ -4,24 +4,23 @@ import {
 } from 'api/rif-marketplace-cache/blockchain/confirmations'
 import { Dispatch } from 'react'
 
-type AgreementContractAction = 'AGREEMENT_NEW' | 'AGREEMENT_WITHDRAW' | 'AGREEMENT_PAYOUT'
+type AgreementContractAction =
+  | 'AGREEMENT_NEW'
+  | 'AGREEMENT_WITHDRAW'
+  | 'AGREEMENT_PAYOUT'
+  | 'AGREEMENT_RENEW'
 type StakingContractAction = 'STAKING_STAKE' | 'STAKING_UNSTAKE'
 
 export type ContractAction =
   | AgreementContractAction
   | StakingContractAction
 
-export type AgreementWithdrawData = {
-  agreementId: string
-}
-
-export type AgreementPayoutData = {
+export type AgreementUpdateData = { // used for withdraw, payout and renew
   agreementId: string
 }
 
 export type AgreementContractData =
-  | AgreementWithdrawData
-  | AgreementPayoutData
+  | AgreementUpdateData
 
 export type ContractActionData =
   | AgreementContractData

--- a/src/context/Confirmations/utils.ts
+++ b/src/context/Confirmations/utils.ts
@@ -3,18 +3,18 @@ import {
 } from './interfaces'
 
 type GetConfirmationsFor = (
-  contractAction: ContractAction,
+  contractActions: ContractAction[],
   confirmations: ConfirmationsRecord
 ) => ConfirmationData[]
 
 const getConfirmationsFor: GetConfirmationsFor = (
-  contractAction,
+  contractActions,
   confirmations,
 ) => (
   Object.values(confirmations).filter(
     ({
       contractAction: confContractAction,
-    }) => confContractAction === contractAction,
+    }) => contractActions.some((conf) => conf === confContractAction),
   )
 )
 

--- a/src/context/storage/mypurchases/renew/Context.tsx
+++ b/src/context/storage/mypurchases/renew/Context.tsx
@@ -17,6 +17,8 @@ import Logger from 'utils/Logger'
 import { convertToWeiString, parseToBigDecimal } from 'utils/parsers'
 import Web3 from 'web3'
 import { SUPPORTED_TOKENS } from 'contracts/interfaces'
+import { ConfirmationsContext, ConfirmationsContextProps } from 'context/Confirmations'
+import { AgreementUpdateData } from 'context/Confirmations/interfaces'
 import { reducer } from './actions'
 import { AsyncActions, Props, State } from './interfaces'
 
@@ -80,6 +82,9 @@ const Provider: FC = ({ children }) => {
       account,
     },
   } = useContext(Web3Store)
+  const {
+    dispatch: confirmationsDispatch,
+  } = useContext<ConfirmationsContextProps>(ConfirmationsContext)
 
   const [isInitialised, setIsInitialised] = useState(false)
   const [asyncActions, setAsyncActions] = useState(initialAsyncActions)
@@ -176,6 +181,16 @@ const Provider: FC = ({ children }) => {
               isDone: true,
             },
           })
+          confirmationsDispatch({
+            type: 'NEW_REQUEST',
+            payload: {
+              txHash: receipt.transactionHash,
+              contractAction: 'AGREEMENT_RENEW',
+              contractActionData: {
+                agreementId: id,
+              } as AgreementUpdateData,
+            },
+          })
           Logger.getInstance().debug('Agreement receipt:', receipt)
         } else {
           dispatch({
@@ -193,7 +208,7 @@ const Provider: FC = ({ children }) => {
       }
       setAsyncActions({ renewAgreement })
     }
-  }, [web3, account, appDispatch, order, reportError])
+  }, [web3, account, appDispatch, order, reportError, confirmationsDispatch])
 
   // Sets current exchange rate and fiat
   const paymentToken = order?.paymentToken

--- a/src/context/storage/mypurchases/withdraw/Context.tsx
+++ b/src/context/storage/mypurchases/withdraw/Context.tsx
@@ -2,7 +2,7 @@ import { Web3Store } from '@rsksmart/rif-ui'
 import { LoadingPayload } from 'context/App/appActions'
 import AppContext, { AppContextProps, errorReporterFactory } from 'context/App/AppContext'
 import { ConfirmationsContext, ConfirmationsContextProps } from 'context/Confirmations'
-import { AgreementWithdrawData } from 'context/Confirmations/interfaces'
+import { AgreementUpdateData } from 'context/Confirmations/interfaces'
 import createWithContext from 'context/storeUtils/createWithContext'
 import { UIError } from 'models/UIMessage'
 import React, {
@@ -109,7 +109,7 @@ const Provider: FC = ({ children }) => {
               txHash: withdrawFundsReceipt.transactionHash,
               contractActionData: {
                 agreementId: id,
-              } as AgreementWithdrawData,
+              } as AgreementUpdateData,
             },
           })
           dispatch({


### PR DESCRIPTION
- Refactor confirmations to be able to get by multiple types
- Joins Withdraw, renew and payout action data types into `AgreementUpdateData`, they all only need `agreementId` for now
- Adds confirmations support for renewing agreements