### PR TITLE
feat: adds useConfirmations custom hook to read specific confs easily

### DIFF
--- a/src/components/organisms/storage/mypurchases/PurchasesTable.tsx
+++ b/src/components/organisms/storage/mypurchases/PurchasesTable.tsx
@@ -5,10 +5,9 @@ import Typography from '@material-ui/core/Typography'
 import RoundBtn from 'components/atoms/RoundBtn'
 import Marketplace from 'components/templates/marketplace/Marketplace'
 import ProgressOverlay from 'components/templates/ProgressOverlay'
-import { ConfirmationsContext, ConfirmationsContextProps } from 'context/Confirmations'
-import getConfirmationsFor from 'context/Confirmations/utils'
 import MarketContext from 'context/Market/MarketContext'
 import withWithdrawContext, { StorageWithdrawContext, StorageWithdrawContextProps } from 'context/storage/mypurchases/withdraw'
+import useConfirmations from 'hooks/useConfirmations'
 import { Agreement } from 'models/marketItems/StorageItem'
 import React, {
   FC, useContext, useEffect, useState,
@@ -53,16 +52,14 @@ const PurchasesTable: FC<PurchasesProps> = (
     },
   } = useContext<StorageWithdrawContextProps>(StorageWithdrawContext)
 
-  const {
-    state: {
-      confirmations,
-    },
-  } = useContext<ConfirmationsContextProps>(ConfirmationsContext)
-
   const [
     itemDetails,
     setItemDetails,
   ] = useState<AgreementCustomerView | undefined>(undefined)
+
+  const withdrawAndRenewConfs = useConfirmations(
+    ['AGREEMENT_WITHDRAW', 'AGREEMENT_RENEW'],
+  )
 
   useEffect(() => {
     // hides modal on tx operation done
@@ -82,10 +79,6 @@ const PurchasesTable: FC<PurchasesProps> = (
       </Typography>
     )
   }
-
-  const withdrawAndRenewConfs = getConfirmationsFor(
-    ['AGREEMENT_WITHDRAW', 'AGREEMENT_RENEW'], confirmations,
-  )
 
   const headers = {
     title: 'Title',

--- a/src/components/pages/storage/myPurchases/Page.tsx
+++ b/src/components/pages/storage/myPurchases/Page.tsx
@@ -19,13 +19,10 @@ import ROUTES from 'routes'
 import { Agreement } from 'models/marketItems/StorageItem'
 import WithLoginCard from 'components/hoc/WithLoginCard'
 import GridRow from 'components/atoms/GridRow'
-import {
-  ConfirmationsContext, ConfirmationsContextProps,
-} from 'context/Confirmations'
-import getConfirmationsFor from 'context/Confirmations/utils'
 import InfoBar from 'components/molecules/InfoBar'
 import PurchasesTable from 'components/organisms/storage/mypurchases/PurchasesTable'
 import AppContext, { AppContextProps } from 'context/App/AppContext'
+import useConfirmations from 'hooks/useConfirmations'
 
 const useTitleStyles = makeStyles(() => ({
   root: {
@@ -50,15 +47,7 @@ const MyStoragePurchases: FC = () => {
     state: { loaders: { data: isLoadingData } },
   } = useContext<AppContextProps>(AppContext)
 
-  const {
-    state: {
-      confirmations,
-    },
-  } = useContext<ConfirmationsContextProps>(ConfirmationsContext)
-
-  const newAgreementsConfsCount = getConfirmationsFor(
-    ['AGREEMENT_NEW'], confirmations,
-  ).length
+  const newAgreementsConfsCount = useConfirmations(['AGREEMENT_NEW']).length
 
   // filters agreements by current account
   useEffect(() => {

--- a/src/hooks/useConfirmations.tsx
+++ b/src/hooks/useConfirmations.tsx
@@ -1,0 +1,21 @@
+import { ConfirmationsContext } from 'context/Confirmations'
+import { ConfirmationData, ContractAction } from 'context/Confirmations/interfaces'
+import getConfirmationsFor from 'context/Confirmations/utils'
+import { useContext } from 'react'
+
+// ================================================================
+// this custom hook is only supposed to be used on ConfirmationsContextProvider
+// children components
+// ================================================================
+
+const useConfirmations = (
+  contractActions: ContractAction[],
+): ConfirmationData[] => {
+  const {
+    state: { confirmations },
+  } = useContext(ConfirmationsContext)
+
+  return getConfirmationsFor(contractActions, confirmations)
+}
+
+export default useConfirmations


### PR DESCRIPTION
- Adds React custom hook `useConfirmations` to read easily the pending confirmations for a specific action
- Uses this new custom hook in the site (only in agreements as the other ones are not merged yet)
