### PR TITLE
feat(rns): adds sorting for offers

### DIFF
--- a/src/api/models/RnsFilter.ts
+++ b/src/api/models/RnsFilter.ts
@@ -1,11 +1,22 @@
-import { MarketFilter } from 'models/Market'
 import { MinMaxFilter } from 'models/Filters'
 
 export type DomainsSaleStatus = 'owned' | 'placed' | 'sold'
 
-export interface RnsFilter extends MarketFilter {
+export interface RnsFilter {
     price: MinMaxFilter
     name?: string
     status?: DomainsSaleStatus
     ownerAddress?: string
+    expirationDate?: Date
+}
+
+export enum SORT_DIRECTION {
+    'asc' = 1,
+    'desc' = -1,
+}
+
+export type RnsSort = {
+    price?: SORT_DIRECTION
+    name?: SORT_DIRECTION
+    expirationDate?: SORT_DIRECTION
 }

--- a/src/api/models/RnsFilter.ts
+++ b/src/api/models/RnsFilter.ts
@@ -18,5 +18,4 @@ export enum SORT_DIRECTION {
 export type RnsSort = {
     price?: SORT_DIRECTION
     name?: SORT_DIRECTION
-    expirationDate?: SORT_DIRECTION
 }

--- a/src/api/rif-marketplace-cache/rns/offers.ts
+++ b/src/api/rif-marketplace-cache/rns/offers.ts
@@ -1,6 +1,6 @@
 import { Paginated } from '@feathersjs/feathers'
 import { AbstractAPIService, isResultPaginated } from 'api/models/apiService'
-import { RnsFilter } from 'api/models/RnsFilter'
+import { RnsFilter, RnsSort } from 'api/models/RnsFilter'
 import { OfferTransport } from 'api/models/transports'
 import { MinMaxFilter } from 'models/Filters'
 import { RnsDomainOffer } from 'models/marketItems/DomainItem'
@@ -72,8 +72,10 @@ export class OffersService extends AbstractAPIService implements RnsAPIService {
 
   _channel = offersChannel
 
-  _fetch = async (filters: Partial<RnsFilter> & { skip?: number}): Promise<RnsDomainOffer[]> => {
-    const { price, name, skip } = filters
+  _fetch = async (props: Partial<RnsFilter> & { skip?: number} & { sort: RnsSort}): Promise<RnsDomainOffer[]> => {
+    const {
+      price, name, skip, sort,
+    } = props
 
     const results: Paginated<OfferTransport> = await this.service.find({
       query: {
@@ -86,6 +88,12 @@ export class OffersService extends AbstractAPIService implements RnsAPIService {
           $gte: convertToBigString(price.min, 18),
           $lte: convertToBigString(price.max, 18),
         } : undefined,
+        $sort: sort && {
+          domain: sort.name ? {
+            name: sort.name,
+          } : undefined,
+          price: sort.price,
+        },
         $skip: skip,
       },
     })

--- a/src/components/pages/rns/buy/DomainOffersPage.tsx
+++ b/src/components/pages/rns/buy/DomainOffersPage.tsx
@@ -17,7 +17,6 @@ import { TableSortLabel } from '@material-ui/core'
 enum SORT_TO_HEADER {
   name = 'domainName',
   price = 'combinedPrice',
-  expirationDate = 'expirationDate',
 }
 
 const isSortedOn = (
@@ -116,20 +115,7 @@ const DomainOffersPage: FC = () => {
       </TableSortLabel>
     ),
     ownerAddress: 'Owner',
-    expirationDate: (
-      <TableSortLabel
-        active={isSortedOn(SORT_TO_HEADER.expirationDate, sortedBy)}
-        direction={SORT_DIRECTION[sortDirection] as ('asc' | 'desc')}
-        onClick={(): void => {
-          triggerSort({
-            expirationDate: getNewSortDirection(
-              SORT_TO_HEADER.expirationDate, sortedBy, sortDirection,
-            ),
-          })
-        }}
-      >
-        Renewal Date
-      </TableSortLabel>),
+    expirationDate: 'Renewal Date',
     combinedPrice: (
       <TableSortLabel
         active={isSortedOn(SORT_TO_HEADER.price, sortedBy)}

--- a/src/components/pages/rns/buy/DomainOffersPage.tsx
+++ b/src/components/pages/rns/buy/DomainOffersPage.tsx
@@ -177,7 +177,7 @@ const DomainOffersPage: FC = () => {
           priceFiat={price.times(rate).toString()}
           currency={displayName}
           currencyFiat={currentFiat.displayName}
-          divider=" = "
+          divider=""
         />,
         action1: (account?.toLowerCase() === ownerAddress.toLowerCase()) ? 'your offer' : (
           <SelectRowButton

--- a/src/components/pages/rns/buy/DomainOffersPage.tsx
+++ b/src/components/pages/rns/buy/DomainOffersPage.tsx
@@ -11,6 +11,25 @@ import MarketContext from 'context/Market/MarketContext'
 import RnsOffersContext, { RnsOffersContextProps } from 'context/Services/rns/OffersContext'
 import { OrderPayload, RefreshPayload } from 'context/Services/rns/rnsActions'
 import { MarketplaceItem } from 'components/templates/marketplace/Marketplace'
+import { RnsSort, SORT_DIRECTION } from 'api/models/RnsFilter'
+import { TableSortLabel } from '@material-ui/core'
+
+enum SORT_TO_HEADER {
+  name = 'domainName',
+  price = 'combinedPrice',
+  expirationDate = 'expirationDate',
+}
+
+const isSortedOn = (
+  header: SORT_TO_HEADER, sortedBy: string,
+): boolean => SORT_TO_HEADER[sortedBy] === header
+
+const getNewSortDirection = (
+  header: SORT_TO_HEADER, sortedBy: string, currentSortDirection: SORT_DIRECTION,
+): SORT_DIRECTION => {
+  if (isSortedOn(header, sortedBy)) return currentSortDirection > 0 ? -1 : 1
+  return 1
+}
 
 const DomainOffersPage: FC = () => {
   const {
@@ -28,6 +47,7 @@ const DomainOffersPage: FC = () => {
         outdatedTokens,
       },
       filters,
+      sort,
       pagination: {
         current: currentPage,
       },
@@ -69,11 +89,61 @@ const DomainOffersPage: FC = () => {
     )
   }
 
+  const sortedBy = Object.keys(sort)[0]
+  const sortDirection = sort[sortedBy]
+
+  const triggerSort = (by: RnsSort): void => {
+    dispatch({
+      type: 'SET_SORT',
+      payload: by,
+    })
+  }
+
   const headers = {
-    domainName: 'Name',
+    domainName: (
+      <TableSortLabel
+        active={isSortedOn(SORT_TO_HEADER.name, sortedBy)}
+        direction={SORT_DIRECTION[sortDirection] as ('asc' | 'desc')}
+        onClick={(): void => {
+          triggerSort({
+            name: getNewSortDirection(
+              SORT_TO_HEADER.name, sortedBy, sortDirection,
+            ),
+          })
+        }}
+      >
+        Name
+      </TableSortLabel>
+    ),
     ownerAddress: 'Owner',
-    expirationDate: 'Renewal Date',
-    combinedPrice: 'Price',
+    expirationDate: (
+      <TableSortLabel
+        active={isSortedOn(SORT_TO_HEADER.expirationDate, sortedBy)}
+        direction={SORT_DIRECTION[sortDirection] as ('asc' | 'desc')}
+        onClick={(): void => {
+          triggerSort({
+            expirationDate: getNewSortDirection(
+              SORT_TO_HEADER.expirationDate, sortedBy, sortDirection,
+            ),
+          })
+        }}
+      >
+        Renewal Date
+      </TableSortLabel>),
+    combinedPrice: (
+      <TableSortLabel
+        active={isSortedOn(SORT_TO_HEADER.price, sortedBy)}
+        direction={SORT_DIRECTION[sortDirection] as ('asc' | 'desc')}
+        onClick={(): void => {
+          triggerSort({
+            price: getNewSortDirection(
+              SORT_TO_HEADER.price, sortedBy, sortDirection,
+            ),
+          })
+        }}
+      >
+        Price
+      </TableSortLabel>),
     action1: action1Header,
   }
 

--- a/src/context/Services/rns/OffersContext.tsx
+++ b/src/context/Services/rns/OffersContext.tsx
@@ -1,5 +1,5 @@
 import { ServiceMetadata } from 'api/models/apiService'
-import { RnsFilter } from 'api/models/RnsFilter'
+import { RnsFilter, RnsSort, SORT_DIRECTION } from 'api/models/RnsFilter'
 import { OffersService } from 'api/rif-marketplace-cache/rns/offers'
 import { RnsDomainOffer } from 'models/marketItems/DomainItem'
 import React, {
@@ -27,6 +27,7 @@ export type OffersState = Modify<RnsState, {
   filters: Pick<RnsFilter, 'name' | 'price'>
   limits: Pick<RnsFilter, 'price'>
   order?: Order
+  sort: RnsSort
 }>
 
 export type RnsOffersContextProps = Modify<RnsContextProps, {
@@ -53,6 +54,9 @@ export const initialState: OffersState = {
   },
   needsRefresh: false,
   pagination: {},
+  sort: {
+    name: SORT_DIRECTION.asc,
+  },
 }
 
 const RnsOffersContext = React.createContext({} as RnsOffersContextProps | any)
@@ -68,12 +72,13 @@ export const RnsOffersContextProvider = ({ children }) => {
   const [state, dispatch] = useReducer(offersReducer, initialState)
   const {
     filters,
+    sort,
     limits,
     needsRefresh,
     pagination: {
       page,
     },
-  } = state as RnsState
+  } = state as OffersState
 
   // Initialise
   useEffect(() => {
@@ -163,7 +168,7 @@ export const RnsOffersContextProvider = ({ children }) => {
           id: 'data',
         } as LoadingPayload,
       } as any)
-      api.fetch({ ...filters, skip: page })
+      api.fetch({ ...filters, skip: page, sort })
         .then((items) => {
           dispatch({
             type: 'SET_LISTING',
@@ -186,7 +191,7 @@ export const RnsOffersContextProvider = ({ children }) => {
           } as any)
         })
     }
-  }, [isInitialised, isLimitsSet, filters, page, limits, api, appDispatch])
+  }, [isInitialised, isLimitsSet, filters, sort, page, limits, api, appDispatch])
 
   const meta = api?.meta
 

--- a/src/context/Services/rns/rnsActions.ts
+++ b/src/context/Services/rns/rnsActions.ts
@@ -1,4 +1,4 @@
-import { RnsFilter } from 'api/models/RnsFilter'
+import { RnsFilter, RnsSort } from 'api/models/RnsFilter'
 import { RnsItem } from 'models/marketItems/DomainItem'
 import { ContextPayload, ContextDispatch } from 'context/storeUtils/interfaces'
 import { ServiceMetadata } from 'api/models/apiService'
@@ -15,6 +15,7 @@ export type RNS_ACTION = 'FILTER'
 | 'UPDATE_PAGE'
 | 'NEXT_PAGE'
 | 'PREV_PAGE'
+| 'SET_SORT'
 
 export type FilterPayload = Partial<RnsFilter>
 
@@ -38,6 +39,8 @@ export type LimitsPayload = Partial<Pick<RnsFilter, 'price'>>
 
 export type PagePayload = ServiceMetadata
 
+export type SortPayload = RnsSort
+
 export type RnsPayload = ContextPayload
   | FilterPayload
   | ListingPayload
@@ -47,6 +50,7 @@ export type RnsPayload = ContextPayload
   | LimitsPayload
   | RefreshPayload
   | PagePayload
+  | SortPayload
 
 export type RnsAction = ContextDispatch<RNS_ACTION, RnsPayload>
 
@@ -66,6 +70,7 @@ export type RnsActions = {
   UPDATE_PAGE: RnsReducer<PagePayload>
   NEXT_PAGE: RnsReducer<{}>
   PREV_PAGE: RnsReducer<{}>
+  SET_SORT: RnsReducer<SortPayload>
 }
 
 export const rnsActions: RnsActions = {
@@ -215,4 +220,8 @@ export const rnsActions: RnsActions = {
       },
     }
   },
+  SET_SORT: (state: RnsState, sort: SortPayload) => ({
+    ...state,
+    sort,
+  }),
 }


### PR DESCRIPTION
Resolving https://rsklabs.atlassian.net/jira/software/projects/RMKT/boards/60?selectedIssue=RMKT-497  by adding sorting ability to rns offers for name and price fields.

Depends on https://github.com/rsksmart/rif-marketplace-cache/pull/495