### PR TITLE
feat(storage-upload): reads file size limit from service

### DIFF
--- a/src/api/rif-storage-upload-service/upload/index.ts
+++ b/src/api/rif-storage-upload-service/upload/index.ts
@@ -33,6 +33,21 @@ export default class UploadService
       return Big(fileSizeBytes)
     }
 
+    getFileSizeLimit = async (): Promise<Big> => {
+      const response = await fetch(`${UPLOAD_ADDRESS}/fileSizeLimit`)
+
+      if (response.status !== 200) {
+        throw new UIError({
+          error: new Error(await response.json()),
+          text: 'Error: Could not get file size limit',
+          id: 'service-fetch',
+        })
+      }
+      const { fileSizeLimit } = await response.json()
+
+      return Big(fileSizeLimit)
+    }
+
     post = async ({
       files, account, offerId, peerId, contractAddress,
     }: StorageUploadArgs): Promise<UploadResponse> => {

--- a/src/api/rif-storage-upload-service/upload/interfaces.ts
+++ b/src/api/rif-storage-upload-service/upload/interfaces.ts
@@ -3,14 +3,14 @@ import { APIService } from 'api/models/apiService'
 import { Modify } from 'utils/typeUtils'
 
 export type UploadResponse = {
-    fileHash: string
-    fileSize: number
-    message: string
+  fileHash: string
+  fileSize: number
+  message: string
 }
 
 export type FileSizeResponse = {
-    fileHash: string
-    fileSizeBytes: number
+  fileHash: string
+  fileSizeBytes: number
 }
 
 export const serviceAddress = 'upload' as const
@@ -28,4 +28,5 @@ export type UploadAPIService = Modify<APIService, {
   path: ServiceAddress
   post: (args: StorageUploadArgs) => Promise<UploadResponse>
   fetch: (fileHash: string) => Promise<Big>
+  getFileSizeLimit: () => Promise<Big>
 }>

--- a/src/components/organisms/storage/buy/PinningCard.tsx
+++ b/src/components/organisms/storage/buy/PinningCard.tsx
@@ -125,11 +125,10 @@ const PinningCard: FC<Props> = ({ dispatch }) => {
   const uploadActionProps: ButtonProps = {
     children: `Upload ${hasSize ? `${sizeUnit.toFixed(3)} ${UNIT_BYTES}` : ''}`,
     onClick: handleUpload,
-    disabled: uploadDisabled,
+    disabled: uploadDisabled || !hasSize,
   }
 
   const sizeOverLimitMB = uploadDisabled
-    && hasSize
     && parseConvertBig(
       size.minus(fileSizeLimit),
       UNIT_PREFIX_POW2.MEGA,

--- a/src/components/organisms/storage/buy/PinningCard.tsx
+++ b/src/components/organisms/storage/buy/PinningCard.tsx
@@ -25,7 +25,7 @@ const UNIT = UNIT_PREFIX_POW2.MEGA
 const UNIT_BYTES = `${UNIT_PREFIX_POW2[UNIT][0]}B`
 
 type Props = {
-    dispatch: Dispatch<StorageCheckoutAction>
+  dispatch: Dispatch<StorageCheckoutAction>
 }
 
 const useActionButtonStyles = makeStyles(() => ({
@@ -34,7 +34,6 @@ const useActionButtonStyles = makeStyles(() => ({
   },
 }))
 
-const TOTAL_SIZE_LIMIT = UNIT_PREFIX_POW2.GIGA
 const CID_PREFIX = '/ipfs/'
 
 const hashErrorEndorment = (): JSX.Element => (
@@ -55,6 +54,7 @@ const PinningCard: FC<Props> = ({ dispatch }) => {
         inProgress,
         isDone,
       },
+      fileSizeLimit,
     },
     asyncActions: {
       uploadFiles,
@@ -102,7 +102,7 @@ const PinningCard: FC<Props> = ({ dispatch }) => {
 
     setSize(totalB)
     setUploadDisabled(!!addedFiles.length
-                && totalB.gt(TOTAL_SIZE_LIMIT))
+      && totalB.gt(fileSizeLimit))
     setFiles(addedFiles)
   }
 
@@ -135,7 +135,7 @@ const PinningCard: FC<Props> = ({ dispatch }) => {
   const sizeOverLimitMB = uploadDisabled
     && hasSize
     && parseConvertBig(
-      size.minus(TOTAL_SIZE_LIMIT),
+      size.minus(fileSizeLimit),
       UNIT_PREFIX_POW2.MEGA,
     ).toFixed(3)
 
@@ -158,7 +158,7 @@ const PinningCard: FC<Props> = ({ dispatch }) => {
     return (
       <StorageUploadAction
         sizeOverLimitMB={sizeOverLimitMB}
-        maxSizeMB={parseConvertBig(TOTAL_SIZE_LIMIT,
+        maxSizeMB={parseConvertBig(fileSizeLimit,
           UNIT_PREFIX_POW2.MEGA).toString()}
         classes={actionBtnClasses}
         {...uploadActionProps}
@@ -204,7 +204,7 @@ const PinningCard: FC<Props> = ({ dispatch }) => {
           <PinUploaderTab
             onChange={onFilesChange}
             filesLimit={666 * 666 * 666}
-            maxFileSize={Big(TOTAL_SIZE_LIMIT).minus(size).toNumber()}
+            maxFileSize={fileSizeLimit.minus(size).toNumber()}
           />
         )}
     </RifCard>

--- a/src/context/Services/storage/upload/Context.tsx
+++ b/src/context/Services/storage/upload/Context.tsx
@@ -30,6 +30,9 @@ export const initialState: State = {
   contextID,
   status: {},
   fileSizeLimit: Big(UNIT_PREFIX_POW2.GIGA), // 1GB by default
+  isLoading: {
+    sizeLimit: false,
+  },
 }
 
 const initialAsyncActions: AsyncActions = {
@@ -87,6 +90,10 @@ export const Provider: FC = ({ children }) => {
 
   // fetch size limit
   useEffect(() => {
+    dispatch({
+      type: 'SET_IS_LOADING',
+      payload: { sizeLimit: true },
+    })
     getFileSizeLimit().then(
       (fileSizeLimit) => {
         dispatch({
@@ -100,7 +107,10 @@ export const Provider: FC = ({ children }) => {
         id: 'service-fetch',
         text: 'Could not get file size limit.',
       }))
-    })
+    }).finally(() => dispatch({
+      type: 'SET_IS_LOADING',
+      payload: { sizeLimit: false },
+    }))
   }, [
     reportError,
     getFileSizeLimit,

--- a/src/context/Services/storage/upload/actions.ts
+++ b/src/context/Services/storage/upload/actions.ts
@@ -12,6 +12,10 @@ const actions: Actions = {
     ...state,
     fileSizeLimit,
   }),
+  SET_IS_LOADING: (state, { sizeLimit }) => ({
+    ...state,
+    isLoading: { sizeLimit },
+  }),
 }
 
 export default actions

--- a/src/context/Services/storage/upload/actions.ts
+++ b/src/context/Services/storage/upload/actions.ts
@@ -8,6 +8,10 @@ const actions: Actions = {
       ...payload,
     },
   }),
+  SET_SIZE_LIMIT: (state, { fileSizeLimit }) => ({
+    ...state,
+    fileSizeLimit,
+  }),
 }
 
 export default actions

--- a/src/context/Services/storage/upload/interfaces.ts
+++ b/src/context/Services/storage/upload/interfaces.ts
@@ -12,7 +12,6 @@ export type State = ContextState & {
   fileSizeLimit: Big
   isLoading: {
     sizeLimit: boolean
-    // filesSize: boolean TBD in order to show loder while uploading files
   }
 }
 
@@ -28,9 +27,6 @@ export type SizeLimitPayload = {
 export type IsLoadingPayload = {
   sizeLimit: boolean
 }
-// | {
-//   filesSize: boolean
-// } TBD in order to show loader while uploading files
 
 // ACTIONS
 export type Action = (

--- a/src/context/Services/storage/upload/interfaces.ts
+++ b/src/context/Services/storage/upload/interfaces.ts
@@ -10,6 +10,10 @@ export type State = ContextState & {
     uploadResponse?: UploadResponse
   }
   fileSizeLimit: Big
+  isLoading: {
+    sizeLimit: boolean
+    // filesSize: boolean TBD in order to show loder while uploading files
+  }
 }
 
 // PAYLOAD
@@ -20,6 +24,13 @@ type StatusPayload = Status & {
 export type SizeLimitPayload = {
   fileSizeLimit: Big
 }
+
+export type IsLoadingPayload = {
+  sizeLimit: boolean
+}
+// | {
+//   filesSize: boolean
+// } TBD in order to show loader while uploading files
 
 // ACTIONS
 export type Action = (
@@ -32,6 +43,7 @@ export type Action = (
 export type Actions = {
   SET_STATUS: (state: State, payload: StatusPayload) => State
   SET_SIZE_LIMIT: (state: State, payload: SizeLimitPayload) => State
+  SET_IS_LOADING: (state: State, payload: IsLoadingPayload) => State
 }
 
 export type AsyncAction<ARGS, RETURN> = {

--- a/src/context/Services/storage/upload/interfaces.ts
+++ b/src/context/Services/storage/upload/interfaces.ts
@@ -9,11 +9,16 @@ export type State = ContextState & {
   status: Status & {
     uploadResponse?: UploadResponse
   }
+  fileSizeLimit: Big
 }
 
 // PAYLOAD
 type StatusPayload = Status & {
   uploadResponse?: UploadResponse
+}
+
+export type SizeLimitPayload = {
+  fileSizeLimit: Big
 }
 
 // ACTIONS
@@ -26,6 +31,7 @@ export type Action = (
 
 export type Actions = {
   SET_STATUS: (state: State, payload: StatusPayload) => State
+  SET_SIZE_LIMIT: (state: State, payload: SizeLimitPayload) => State
 }
 
 export type AsyncAction<ARGS, RETURN> = {
@@ -42,7 +48,7 @@ export type AsyncActions = {
 
 // PROPS
 export type Props = {
-    state: State
-    dispatch: Dispatch<Action>
-    asyncActions: AsyncActions
+  state: State
+  dispatch: Dispatch<Action>
+  asyncActions: AsyncActions
 }


### PR DESCRIPTION
Now on https://github.com/rsksmart/rif-marketplace-ui/pull/662

~- Gets file size limit from upload-service~
~- Shows max size text~
~- Disables upload button until there is content to be uploaded~

~By default it's set to 1GB in UI. This allows us to always handle a value without having to "pause" the flow until we have the max size defined~