### PR TITLE
feat: adds notifier staking interaction with SC

### DIFF
--- a/src/components/organisms/notifier/Staking.tsx
+++ b/src/components/organisms/notifier/Staking.tsx
@@ -1,24 +1,107 @@
-import React, { FC } from 'react'
+import React, { FC, useContext, useState } from 'react'
 import { StakedBalances } from 'api/rif-marketplace-cache/storage/stakes'
+import { SupportedTokenSymbol } from 'models/Token'
+import NotifierStakingContract from 'contracts/notifier/Staking'
+import { Web3Store } from '@rsksmart/rif-ui'
+import Web3 from 'web3'
+import RoundBtn from 'components/atoms/RoundBtn'
+import ProgressOverlay from 'components/templates/ProgressOverlay'
+import useErrorReporter from 'hooks/useErrorReporter'
+import Big from 'big.js'
 import StakingTemplate from '../staking/StakingTemplate'
 
 type Props = {
   isEnabled: boolean
 }
 
+const stakeInProgressMsg = 'Staking your funds'
+const stakeCompletedMsg = 'Your funds have been staked!'
+const unstakeInProgressMsg = 'Unstaking your funds'
+const unstakeCompletedMsg = 'Your funds have been unstaked!'
+
 const Staking: FC<Props> = ({ isEnabled }) => {
+  const {
+    state: {
+      account,
+      web3,
+    },
+  } = useContext(Web3Store)
+
+  const reportError = useErrorReporter()
+
+  const [txInProgressMessage, setTxInProgressMessage] = useState('')
+  const [txCompleteMsg, setTxCompleteMsg] = useState('')
+  const [processingTx, setProcessingTx] = useState(false)
+  const [txOperationDone, setTxOperationDone] = useState(false)
+
+  // TODO: add real data
   const isProcessing = false
   const stakedBalances = {} as StakedBalances
   const totalStakedUSD = ''
 
   const canWithdraw = async (): Promise<boolean> => {
+    // TODO: add specific validation logic
     await new Promise((resolve) => setTimeout(resolve, 1000))
 
-    return false
+    return true
   }
 
-  const handleDeposit = (): Promise<void> => Promise.resolve()
-  const handleWithdraw = (): Promise<void> => Promise.resolve()
+  const handleDeposit = async (
+    amount: number, currency: SupportedTokenSymbol,
+  ): Promise<void> => {
+    try {
+      setTxInProgressMessage(stakeInProgressMsg)
+      setProcessingTx(true)
+      setTxCompleteMsg(stakeCompletedMsg)
+      const stakingContract = NotifierStakingContract.getInstance(web3 as Web3)
+      const receipt = await stakingContract.stake(Big(amount), {
+        token: currency,
+        from: account,
+      })
+
+      if (receipt) {
+        setTxOperationDone(true)
+        // TODO: send confirmation track request
+      }
+    } catch (error) {
+      const { customMessage } = error
+      reportError({
+        error,
+        id: 'contract-notifier-staking',
+        text: customMessage || 'Could not stake funds.',
+      })
+    } finally {
+      setProcessingTx(false)
+    }
+  }
+
+  const handleWithdraw = async (
+    amount: number, currency: SupportedTokenSymbol,
+  ): Promise<void> => {
+    try {
+      setTxInProgressMessage(unstakeInProgressMsg)
+      setProcessingTx(true)
+      setTxCompleteMsg(unstakeCompletedMsg)
+      const stakeContract = NotifierStakingContract.getInstance(web3 as Web3)
+      const receipt = await stakeContract.unstake(
+        Big(amount), { token: currency, from: account },
+      )
+
+      if (receipt) {
+        setTxOperationDone(true)
+        // TODO: add confirmations tracking
+      }
+    } catch (error) {
+      const { customMessage } = error
+      reportError({
+        error,
+        id: 'contract-notifier-staking',
+        text: customMessage || 'Could not withdraw your funds.',
+      })
+    } finally {
+      setProcessingTx(false)
+    }
+  }
 
   return (
     <>
@@ -30,6 +113,19 @@ const Staking: FC<Props> = ({ isEnabled }) => {
         totalStakedUSD={totalStakedUSD}
         onDeposit={handleDeposit}
         onWithdraw={handleWithdraw}
+      />
+      <ProgressOverlay
+        title={txInProgressMessage}
+        doneMsg={txCompleteMsg}
+        inProgress={processingTx}
+        isDone={txOperationDone}
+        buttons={[
+          <RoundBtn
+            onClick={(): void => setTxOperationDone(false)}
+          >
+            Close
+          </RoundBtn>,
+        ]}
       />
     </>
   )

--- a/src/components/organisms/storage/staking/Staking.tsx
+++ b/src/components/organisms/storage/staking/Staking.tsx
@@ -56,7 +56,7 @@ const Staking: FC = () => {
   } = useContext<StorageGlobalContextProps>(StorageGlobalContext)
 
   const isAwaitingConfirmations = Boolean(
-    useConfirmations(['STAKING_STAKE', 'STAKING_UNSTAKE']).length,
+    useConfirmations(['STORAGE_STAKE', 'STORAGE_UNSTAKE']).length,
   )
 
   const [txInProgressMessage, setTxInProgressMessage] = useState('')
@@ -96,7 +96,7 @@ const Staking: FC = () => {
         confirmationsDispatch({
           type: 'NEW_REQUEST',
           payload: {
-            contractAction: 'STAKING_STAKE',
+            contractAction: 'STORAGE_STAKE',
             txHash: receipt.transactionHash,
           },
         })
@@ -131,7 +131,7 @@ const Staking: FC = () => {
         confirmationsDispatch({
           type: 'NEW_REQUEST',
           payload: {
-            contractAction: 'STAKING_UNSTAKE',
+            contractAction: 'STORAGE_UNSTAKE',
             txHash: receipt.transactionHash,
           },
         })

--- a/src/context/Confirmations/interfaces.ts
+++ b/src/context/Confirmations/interfaces.ts
@@ -24,12 +24,14 @@ type RnsContractAction =
   | PlaceDomainAction
 
 type NotifierContractAction = 'NOTIFIER_REGISTER_PROVIDER'
+type NotifierStakingContractAction = 'NOTIFIER_STAKE' | 'NOTIFIER_UNSTAKE'
 
 export type ContractAction =
   | StorageContractAction
   | StorageStakingContractAction
   | RnsContractAction
   | NotifierContractAction
+  | NotifierStakingContractAction
 
 export type AgreementUpdateData = { // used for withdraw, payout and renew
   agreementId: string

--- a/src/context/Confirmations/interfaces.ts
+++ b/src/context/Confirmations/interfaces.ts
@@ -11,7 +11,7 @@ type AgreementContractAction =
   | 'AGREEMENT_RENEW'
 
 type OfferContractAction = 'NEW_OFFER' | 'EDIT_OFFER' | 'CANCEL_OFFER'
-type StorageStakingContractAction = 'STAKING_STAKE' | 'STAKING_UNSTAKE'
+type StorageStakingContractAction = 'STORAGE_STAKE' | 'STORAGE_UNSTAKE'
 
 type StorageContractAction = AgreementContractAction | OfferContractAction
 

--- a/src/contracts/config.ts
+++ b/src/contracts/config.ts
@@ -20,7 +20,7 @@ const {
 const marketPlaceAddress = marketplace.toLowerCase()
 const rnsAddress = rnsDotRskOwner.toLowerCase()
 const storageAddress = storageManager.toLowerCase()
-const stakingAddress = storageStaking.toLowerCase()
+const storageStakingAddress = storageStaking.toLowerCase()
 const notifierAddress = notificationsManager.toLowerCase()
 
 const rnsSupportedTokens: SupportedTokenSymbol[] = services.rns.tokens
@@ -49,7 +49,7 @@ export {
   marketPlaceAddress,
   rnsAddress,
   storageAddress,
-  stakingAddress,
+  storageStakingAddress,
   allAllowedPaymentTokens,
   allTokenAddresses,
   addressTokenRecord,

--- a/src/contracts/config.ts
+++ b/src/contracts/config.ts
@@ -14,6 +14,7 @@ const {
   storageManager,
   storageStaking,
   notificationsManager,
+  notificationsStaking,
   ...tokenAddresses
 } = contractAddresses
 
@@ -22,6 +23,7 @@ const rnsAddress = rnsDotRskOwner.toLowerCase()
 const storageAddress = storageManager.toLowerCase()
 const storageStakingAddress = storageStaking.toLowerCase()
 const notifierAddress = notificationsManager.toLowerCase()
+const notifierStakingAddress = notificationsStaking.toLowerCase()
 
 const rnsSupportedTokens: SupportedTokenSymbol[] = services.rns.tokens
 const storageSupportedTokens: SupportedTokenSymbol[] = services.storage.tokens
@@ -58,4 +60,5 @@ export {
   rifTokenAddress,
   notifierAddress,
   notifierSupportedTokens,
+  notifierStakingAddress,
 }

--- a/src/contracts/interfaces.ts
+++ b/src/contracts/interfaces.ts
@@ -12,6 +12,7 @@ import { StorageContractErrorId } from './storage/Storage'
 import type { RifERC677ContractErrorId, RifERC20ContractErrorId } from './tokens/rif'
 import { PaymentWrapper } from './wrappers/payment-wrapper'
 import { NotifierContractErrorId } from './notifier/Notifier'
+import { NotifierStakingContractErrorId } from './notifier/Staking'
 
 export interface TransactionOptions {
   from?: string
@@ -37,6 +38,7 @@ export type ContractErrorId =
   | StorageContractErrorId
   | StorageStakingContractErrorId
   | NotifierContractErrorId
+  | NotifierStakingContractErrorId
 
 export enum TOKEN_TYPES {
   ERC20 = 'erc20',

--- a/src/contracts/notifier/Staking.ts
+++ b/src/contracts/notifier/Staking.ts
@@ -1,0 +1,95 @@
+import Staking from '@rsksmart/rif-marketplace-notifications/build/contracts/Staking.json'
+import { notifierStakingAddress, notifierSupportedTokens } from 'contracts/config'
+import { TxOptions } from 'contracts/interfaces'
+import { validateBalance } from 'contracts/utils/accountBalance'
+import ContractWithTokens from 'contracts/wrappers/contract-using-tokens'
+import CustomError from 'models/CustomError'
+import { convertToWeiString } from 'utils/parsers'
+import { getTokensFromConfigTokens } from 'utils/tokenUtils'
+import Web3 from 'web3'
+import { TransactionReceipt } from 'web3-eth'
+import { AbiItem } from 'web3-utils'
+import Big from 'big.js'
+import { ZERO_BYTES } from 'constants/strings'
+
+export type NotifierStakingContractErrorId = 'contract-notifier-staking'
+
+class NotifierStakingContract extends ContractWithTokens {
+  public static gasMultiplier = 1.1
+
+  public static getInstance(web3: Web3): NotifierStakingContract {
+    if (!NotifierStakingContract.instance) {
+      NotifierStakingContract.instance = new NotifierStakingContract(
+        web3,
+        new web3.eth.Contract(
+          Staking.abi as AbiItem[],
+          notifierStakingAddress,
+        ),
+        getTokensFromConfigTokens(notifierSupportedTokens),
+        'contract-notifier-staking',
+      )
+    }
+    return NotifierStakingContract.instance
+  }
+
+  private static instance: NotifierStakingContract
+
+  public async stake(
+    amount: Big,
+    txOptions: TxOptions,
+  ): Promise<TransactionReceipt> {
+    if (Big(amount).lte(Big(0))) {
+      throw new CustomError('The amount to stake should be greater then 0.')
+    }
+
+    const { from: account, token } = txOptions
+    const { tokenAddress } = this.getToken(token)
+    const amountWei = convertToWeiString(amount)
+
+    await validateBalance({
+      web3: this.web3, minAmountWei: amountWei, account, token,
+    })
+
+    const stakeTx = this.methods.stake(
+      amountWei,
+      tokenAddress,
+      ZERO_BYTES,
+    )
+
+    return this.send(
+      stakeTx,
+      {
+        gasMultiplier: NotifierStakingContract.gasMultiplier,
+        ...txOptions,
+        value: amountWei,
+      },
+    )
+  }
+
+  public unstake(
+    amount: Big,
+    txOptions: TxOptions,
+  ): Promise<TransactionReceipt> {
+    if (Big(amount).lte(Big(0))) {
+      throw new CustomError('The amount to unstake should be greater then 0.')
+    }
+
+    const { tokenAddress } = this.getToken(txOptions.token)
+    const amountWei = convertToWeiString(amount)
+
+    const unstakeTx = this.methods.unstake(
+      amountWei,
+      tokenAddress,
+      ZERO_BYTES,
+    )
+    return this.send(
+      unstakeTx,
+      {
+        gasMultiplier: NotifierStakingContract.gasMultiplier,
+        ...txOptions,
+      },
+    )
+  }
+}
+
+export default NotifierStakingContract

--- a/src/contracts/storage/Staking.ts
+++ b/src/contracts/storage/Staking.ts
@@ -3,9 +3,8 @@ import { convertToWeiString } from 'utils/parsers'
 import Web3 from 'web3'
 import { TransactionReceipt } from 'web3-eth'
 import { AbiItem } from 'web3-utils'
-
 import { ZERO_BYTES } from 'constants/strings'
-import { stakingAddress, storageSupportedTokens } from 'contracts/config'
+import { storageStakingAddress, storageSupportedTokens } from 'contracts/config'
 import { TxOptions } from 'contracts/interfaces'
 import { getTokensFromConfigTokens } from 'utils/tokenUtils'
 import ContractWithTokens from 'contracts/wrappers/contract-using-tokens'
@@ -25,7 +24,7 @@ class StakingContract extends ContractWithTokens {
         web3,
         new web3.eth.Contract(
           Staking.abi as AbiItem[],
-          stakingAddress,
+          storageStakingAddress,
         ),
         getTokensFromConfigTokens(storageSupportedTokens),
         'contract-storage-staking',


### PR DESCRIPTION
## Features
- Adds Notifier Staking SC wrapper
- Handles stake/unstake in ui

## Known issues
- `canWithdraw` and `stakedBalances` should be read from cache when service is ready

## Demo

#### Stake
https://user-images.githubusercontent.com/8449567/108768704-be84f380-7536-11eb-8d9a-91fa2c8b9262.mov

#### Unstake 
_`totalStakedUSD` needs to be hardcoded with a positive number in order to enable this functionality_

https://user-images.githubusercontent.com/8449567/108769244-7fa36d80-7537-11eb-80d0-f800ddc70244.mov



~Rebased on #717~