### PR TITLE
feat(tests-unit): adds context/confirmations and context/services/notifications tests

### DIFF
--- a/src/context/Confirmations/__tests__/Context.test.tsx
+++ b/src/context/Confirmations/__tests__/Context.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { useProviderTest } from '__tests__/testUtils'
+import { Context, Provider } from '../Context'
+
+const ProviderTest = useProviderTest(
+  Provider, Context,
+)
+describe('Confirmations Context', () => {
+  describe('initialState', () => {
+    test('should contain contextID: "confirmations"', () => {
+      render(<ProviderTest test={({ state: { contextID } }): void => {
+        expect(contextID).toEqual('confirmations')
+      }}
+      />)
+    })
+    test('should contain an empty confirmations object', () => {
+      render(<ProviderTest test={({ state: { confirmations } }): void => {
+        expect(confirmations).toEqual({})
+      }}
+      />)
+    })
+  })
+})

--- a/src/context/Confirmations/__tests__/actions.test.tsx
+++ b/src/context/Confirmations/__tests__/actions.test.tsx
@@ -1,0 +1,115 @@
+import { initialState } from '../Context'
+import {
+  ConfirmationsRecord, ContractAction, NewConfirmationPayload, NewRequestPayload, State,
+} from '../interfaces'
+import actions from '../actions'
+
+const MOCK_THASH = 'MOCK_HASH'
+let state: State
+
+describe('Confirmations Context Actions', () => {
+  beforeEach(() => {
+    state = { ...initialState }
+  })
+  describe('NEW_CONFIRMATION', () => {
+    test('should return state with added confirmations when payload.confirmations < payload.targetConfirmation', () => {
+      const expectedConfirmation = {
+        currentCount: 2,
+        targetCount: 20,
+        contractAction: 'STAKING_STAKE' as ContractAction,
+      }
+
+      const payload: NewConfirmationPayload = {
+        confirmations: expectedConfirmation.currentCount,
+        event: 'MOCK_EVENT',
+        targetConfirmation: expectedConfirmation.targetCount,
+        transactionHash: MOCK_THASH,
+      }
+
+      state.confirmations = {
+        [MOCK_THASH]: {
+          ...expectedConfirmation,
+          currentCount: 1,
+        },
+      }
+
+      const {
+        confirmations,
+      }: Partial<State> = actions.NEW_CONFIRMATION(
+        state, payload,
+      )
+
+      expect(confirmations[MOCK_THASH]).toBeTruthy()
+      expect(confirmations[MOCK_THASH]).toEqual(expectedConfirmation)
+    })
+
+    test('should return state with no change when transaction hash is not present in state.confirmations', () => {
+      const payload: NewConfirmationPayload = {
+        confirmations: 4,
+        event: 'MOCK_EVENT',
+        targetConfirmation: 20,
+        transactionHash: MOCK_THASH,
+      }
+
+      const {
+        confirmations,
+      }: Partial<State> = actions.NEW_CONFIRMATION(
+        state, payload,
+      )
+
+      expect(confirmations).toBeTruthy()
+      expect(confirmations).toEqual({})
+    })
+
+    test('should return state without given confirmation hash when payload.confirmations >= payload.targetConfirmation', () => {
+      const initialConfirmations = {
+        [MOCK_THASH]: {
+          currentCount: 1,
+          targetCount: 2,
+          contractAction: 'STAKING_STAKE' as ContractAction,
+        },
+      }
+
+      const payload: NewConfirmationPayload = {
+        confirmations: 2,
+        event: 'MOCK_EVENT',
+        targetConfirmation: 2,
+        transactionHash: MOCK_THASH,
+      }
+
+      state.confirmations = initialConfirmations
+      expect(state.confirmations).toEqual(initialConfirmations)
+      const {
+        confirmations,
+      }: Partial<State> = actions.NEW_CONFIRMATION(
+        state, payload,
+      )
+
+      expect(confirmations).toBeTruthy()
+      expect(confirmations.MOCK_EVENT).toEqual(undefined)
+    })
+  })
+
+  describe('NEW_REQUEST', () => {
+    test('should return state with added transaction', () => {
+      const payload: NewRequestPayload = {
+        txHash: MOCK_THASH,
+        contractAction: 'AGREEMENT_NEW',
+      }
+
+      const expectedConfirmations: ConfirmationsRecord = {
+        [MOCK_THASH]: {
+          currentCount: 0,
+          contractAction: 'AGREEMENT_NEW',
+        },
+      }
+
+      const {
+        confirmations,
+      }: Partial<State> = actions.NEW_REQUEST(state, payload)
+
+      expect(confirmations).toBeTruthy()
+      expect(confirmations).toEqual(expectedConfirmations)
+    })
+  })
+})

--- a/src/context/Services/notifications/__tests__/Context.test.tsx
+++ b/src/context/Services/notifications/__tests__/Context.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { useProviderTest } from '__tests__/testUtils'
+import { Context, Provider } from '../Context'
+
+const ProviderTest = useProviderTest(
+  Provider, Context,
+)
+describe('Notifications Context', () => {
+  describe('initialState', () => {
+    test('should contain contextID: "notification"', () => {
+      render(<ProviderTest test={({ state: { contextID } }): void => {
+        expect(contextID).toEqual('notification')
+      }}
+      />)
+    })
+    test('should contain an empty notifications array', () => {
+      render(<ProviderTest test={({ state: { notifications } }): void => {
+        expect(notifications).toEqual([])
+      }}
+      />)
+    })
+  })
+})

--- a/src/context/Services/notifications/__tests__/actions.test.tsx
+++ b/src/context/Services/notifications/__tests__/actions.test.tsx
@@ -1,0 +1,34 @@
+import Big from 'big.js'
+import { MessageCodesEnum } from 'api/rif-marketplace-cache/notifications/interfaces'
+import { initialState } from '../Context'
+import { Notifications, State } from '../interfaces'
+import actions from '../actions'
+
+describe('Notifications Context Actions', () => {
+  describe('SET_NOTIFICATIONS', () => {
+    test('should return NotificationsContext state with new notifications', () => {
+      const payload: Notifications = [
+        {
+          account: 'MOCK_ACCOUNT',
+          payload: {
+            agreementReference: 'MOCK_REFERENCE',
+            code: MessageCodesEnum.E_AGREEMENT_SIZE_LIMIT_EXCEEDED,
+            expectedSize: Big(1),
+            hash: 'MOCK_HASH',
+            size: Big(1),
+            timestamp: 23423,
+          },
+          type: 'MOCK_TYPE',
+        },
+      ]
+      const {
+        notifications,
+      }: Partial<State> = actions.SET_NOTIFICATIONS(
+        initialState, payload,
+      )
+
+      expect(notifications).toBeTruthy()
+      expect(notifications).toEqual(payload)
+    })
+  })
+})


### PR DESCRIPTION
Part of the https://rsklabs.atlassian.net/browse/RMKT-457 ticket.

Please review only the last two commits in this PR (previous come from https://github.com/rsksmart/rif-marketplace-ui/pull/727).