### PR TITLE
chore(deps): bumps rif-ui to v0.6.1 - regtest support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1802,8 +1802,9 @@
       }
     },
     "@rsksmart/rif-ui": {
-      "version": "0.6.0",
-      "resolved": "github:rsksmart/rif-ui#18c2e64bf309199424630c26fd908a223698c0d2"
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rif-ui/-/rif-ui-0.6.1.tgz",
+      "integrity": "sha512-5r1EimLJPYz0kWal77l9ySxI0n/EnhGO0Al/uyBtnukNEJflLfEyY312uEN3W7nui2Py7qmGwy0Td3bkIQ8tZg=="
     },
     "@rsksmart/rsk-utils": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@rsksmart/erc721": "^1.0.0",
     "@rsksmart/rif-marketplace-notifier": "0.0.1-dev.2",
     "@rsksmart/rif-marketplace-storage": "^0.1.0",
-    "@rsksmart/rif-ui": "^0.6.0",
+    "@rsksmart/rif-ui": "^0.6.1",
     "@rsksmart/rsk-utils": "^1.1.0",
     "big.js": "^6.0.2",
     "cids": "^1.0.2",


### PR DESCRIPTION
## Description
Updates `rif-ui` dependency to `v0.6.1` which includes support for RSK Regtest network

## How to test
The following environment configuration could be used for testing:

```
REACT_APP_NETWORK=rskdevnet
REACT_APP_REQUIRED_NETWORK_ID=33
REACT_APP_REQUIRED_NETWORK_NAME="RSK Regtest"
```