### PR TITLE
refactor(roundBtn): make round button more extensible

### DIFF
--- a/src/components/atoms/RoundBtn.tsx
+++ b/src/components/atoms/RoundBtn.tsx
@@ -1,18 +1,16 @@
 import React, { FC } from 'react'
 import {
   ButtonProps,
-} from '@material-ui/core'
+} from '@material-ui/core/Button'
 import { Button } from '@rsksmart/rif-ui'
 
-export type RoundBtnProps = Omit<ButtonProps, 'color' | 'variant'>
-
-const RoundBtn: FC<RoundBtnProps> = (props) => (
+const RoundBtn: FC<ButtonProps> = ({ color = 'primary', variant = 'contained', ...otherProps }) => (
   <Button
-    color="primary"
-    variant="contained"
+    color={color}
+    variant={variant}
     rounded
     shadow
-    {...props}
+    {...otherProps}
   />
 )
 

--- a/src/components/organisms/storage/buy/StoragePurchaseCard.tsx
+++ b/src/components/organisms/storage/buy/StoragePurchaseCard.tsx
@@ -7,20 +7,21 @@ import { Web3Store } from '@rsksmart/rif-ui'
 import GridColumn from 'components/atoms/GridColumn'
 import Login from 'components/atoms/Login'
 import RifCard from 'components/organisms/RifCard'
-import RoundBtn, { RoundBtnProps } from 'components/atoms/RoundBtn'
+import { ButtonProps } from '@material-ui/core/Button'
+import RoundBtn from 'components/atoms/RoundBtn'
 
 type Details = {
-    'CONTENT SIZE': string
-    'CURRENCY TO PAY': JSX.Element
-    'SUBSCRIPTION PERIOD': JSX.Element
-    'PERIODS TO PREPAY': JSX.Element
-    'TOTAL PRICE': JSX.Element | null
-    'RENEWAL DATE': string
-  }
+  'CONTENT SIZE': string
+  'CURRENCY TO PAY': JSX.Element
+  'SUBSCRIPTION PERIOD': JSX.Element
+  'PERIODS TO PREPAY': JSX.Element
+  'TOTAL PRICE': JSX.Element | null
+  'RENEWAL DATE': string
+}
 
 type Props = {
   details: Details
-  submitProps: RoundBtnProps
+  submitProps: ButtonProps
   title: string
 }
 


### PR DESCRIPTION
This PR makes `RoundBtn` component more flexible so it can be used with secondary colors for example.
By default keeps using the same props.