### PR TITLE
feat(notifier): avoids multiple offers creation per provider

### DIFF
--- a/src/api/rif-marketplace-cache/notifier/interfaces.ts
+++ b/src/api/rif-marketplace-cache/notifier/interfaces.ts
@@ -1,5 +1,5 @@
 import { APIService } from 'api/models/apiService'
-import { NotifierSubscriptionsFilters } from 'models/marketItems/NotifierFilters'
+import { NotifierFilters } from 'models/marketItems/NotifierFilters'
 import { NotifierItem } from 'models/marketItems/NotifierItem'
 import { NotifierOffersAddress, NotifierOffersWSChannel } from './offers'
 import { NotifierStakesAddress, NotifierStakesWSChannel } from './stakes'
@@ -17,5 +17,5 @@ export type WSChannel =
 export interface NotifierCacheAPIService extends APIService {
   path: Address
   _channel: WSChannel
-  fetch: (filters?: NotifierSubscriptionsFilters) => Promise<NotifierItem[]>
+  fetch: (filters?: NotifierFilters) => Promise<NotifierItem[]>
 }

--- a/src/api/rif-marketplace-cache/notifier/offers/__tests__/api.test.ts
+++ b/src/api/rif-marketplace-cache/notifier/offers/__tests__/api.test.ts
@@ -2,6 +2,8 @@ import { AbstractAPIService } from 'api/models/apiService'
 import mockFeathersService from 'api/test-utils/feathers'
 import { NotifierOfferItem } from 'models/marketItems/NotifierItem'
 import { SYSTEM_SUPPORTED_SYMBOL } from 'models/Token'
+import { NotifierOffersFilters } from 'models/marketItems/NotifierFilters'
+import { SYSTEM_SUPPORTED_FIAT } from 'models/Fiat'
 import OffersService, { notifierOffersAddress, NotifierOffersTransportModel, notifierOffersWSChannel } from '../index'
 import { mapFromTransport } from '../api'
 import { NotifierOffersService } from '../..'
@@ -33,6 +35,15 @@ const MOCK_ITEM_0: NotifierOffersTransportModel = {
 const MOCK_RESPONSE: NotifierOffersTransportModel[] = [MOCK_ITEM_0]
 
 let offersService: NotifierOffersService
+
+const filters: NotifierOffersFilters = {
+  price: {
+    min: 1,
+    max: 10,
+    fiatSymbol: SYSTEM_SUPPORTED_FIAT.usd,
+  },
+  size: { min: 1, max: 10 },
+}
 
 describe('Notifier Offers Service', () => {
   beforeEach(() => {
@@ -77,12 +88,12 @@ describe('Notifier Offers Service', () => {
     test('should call service find method', async () => {
       const serviceFindSpy = jest.spyOn(offersService.service, 'find')
 
-      await offersService.fetch()
+      await offersService.fetch(filters)
       expect(serviceFindSpy).toBeCalled()
     })
 
     test('should return NotifierOfferItem[] on success', async () => {
-      const actualOffers: NotifierOfferItem[] = await offersService.fetch()
+      const actualOffers: NotifierOfferItem[] = await offersService.fetch(filters)
 
       const expectedOffers: NotifierOfferItem[] = MOCK_RESPONSE
         .map(mapFromTransport)

--- a/src/api/rif-marketplace-cache/notifier/offers/api.ts
+++ b/src/api/rif-marketplace-cache/notifier/offers/api.ts
@@ -37,7 +37,7 @@ export const mapFromTransport = ({
   limit: quantity,
   priceOptions: prices.map((price) => ({
     token: getSupportedTokenByName(
-        price.rateId as SupportedTokenSymbol,
+      price.rateId as SupportedTokenSymbol,
     ),
     value: parseToBigDecimal(price.price),
   })),
@@ -57,13 +57,13 @@ class OffersService extends AbstractAPIService
   _fetch = async (
     filters: NotifierOffersFilters,
   ): Promise<NotifierOfferItem[]> => {
-    const result: Paginated<PlanDTO> = await this.service.find({
-      query: filters && {
-        ...filters,
-        currency: Array.from(filters.currency),
-        channels: Array.from(filters.channels),
-      },
-    })
+    const { currency, channels } = filters
+    const query = filters && {
+      ...filters,
+      currency: currency && Array.from(currency),
+      channels: channels && Array.from(channels),
+    }
+    const result: Paginated<PlanDTO> = await this.service.find({ query })
 
     const { data, ...metadata } = isResultPaginated(result)
       ? result : { data: result }

--- a/src/components/organisms/NoMultipleOffersCard.tsx
+++ b/src/components/organisms/NoMultipleOffersCard.tsx
@@ -15,13 +15,22 @@ const useStyles = makeStyles(() => ({
   },
 }))
 
-const MY_OFFERS_ROUTE = ROUTES.STORAGE.MYOFFERS.BASE
+type Service = 'storage' | 'notifier'
 
-const NoMultipleOffersCard: FC = () => {
+const MY_OFFERS_ROUTE: Record<Service, string> = {
+  storage: ROUTES.STORAGE.MYOFFERS.BASE,
+  notifier: ROUTES.NOTIFIER.MYOFFERS.BASE,
+}
+
+type Props = {
+  service: Service
+}
+
+const NoMultipleOffersCard: FC<Props> = ({ service }) => {
   const classes = useStyles()
   const history = useHistory()
 
-  const navigateMyOffers = (): void => history.push(MY_OFFERS_ROUTE)
+  const navigateMyOffers = (): void => history.push(MY_OFFERS_ROUTE[service])
 
   return (
     <Grid container justify="center">
@@ -40,7 +49,7 @@ const NoMultipleOffersCard: FC = () => {
             An offer is already created for the selected account.
             <br />
             {'You can edit your current offer in '}
-            <NavLink to={MY_OFFERS_ROUTE} className={classes.myOffersLink}>
+            <NavLink to={MY_OFFERS_ROUTE[service]} className={classes.myOffersLink}>
               <Box display="inline" fontWeight="fontWeightMedium">
                 My Offers
               </Box>

--- a/src/components/organisms/notifier/provider/ProviderEdition.tsx
+++ b/src/components/organisms/notifier/provider/ProviderEdition.tsx
@@ -3,7 +3,7 @@ import Typography from '@material-ui/core/Typography'
 import Box from '@material-ui/core/Box'
 import RoundBtn from 'components/atoms/RoundBtn'
 import { Grid } from '@material-ui/core'
-import { ModalDialogue, Web3Store } from '@rsksmart/rif-ui'
+import { ModalDialogue, Web3Store, WithSpinner } from '@rsksmart/rif-ui'
 import NotifierContract from 'contracts/notifier/Notifier'
 import Web3 from 'web3'
 import { ConfirmationsContext } from 'context/Confirmations'
@@ -159,4 +159,4 @@ const ProviderEdition: FC<Props> = (
   )
 }
 
-export default ProviderEdition
+export default WithSpinner(ProviderEdition)

--- a/src/components/pages/notifier/myoffers/NotifierEditOfferPage.tsx
+++ b/src/components/pages/notifier/myoffers/NotifierEditOfferPage.tsx
@@ -15,9 +15,9 @@ const NotifierEditOfferPage: FC = () => {
     },
   } = useContext(Web3Store)
   const history = useHistory()
-  const hasPendingConfs = useConfirmations(
+  const hasPendingConfs = Boolean(useConfirmations(
     ['NOTIFIER_REGISTER_PROVIDER'],
-  ).length
+  ).length)
 
   if (!account) {
     history.push(ROUTES.NOTIFIER.BASE)
@@ -27,7 +27,7 @@ const NotifierEditOfferPage: FC = () => {
   return (
     <CenteredPageTemplate>
       <InfoBar
-        isVisible={Boolean(hasPendingConfs)}
+        isVisible={hasPendingConfs}
         text="Awaiting confirmations for provider registration"
         type="info"
       />
@@ -38,7 +38,7 @@ const NotifierEditOfferPage: FC = () => {
         {`Fill out the fields below to edit your trigger offer. 
         All the information provided is meant to be true and correct.`}
       </Typography>
-      <ProviderEdition editMode />
+      <ProviderEdition isLoading={hasPendingConfs} editMode />
     </CenteredPageTemplate>
   )
 }

--- a/src/components/pages/notifier/sell/NotifierSellPage.tsx
+++ b/src/components/pages/notifier/sell/NotifierSellPage.tsx
@@ -13,9 +13,10 @@ import React, {
 } from 'react'
 import Web3 from 'web3'
 import AppContext from 'context/App'
-import { NotifierOffersService } from 'api/rif-marketplace-cache/notifier'
 import WithLoginCard from 'components/hoc/WithLoginCard'
 import NoMultipleOffersCard from 'components/organisms/NoMultipleOffersCard'
+import { NotifierCacheAPIService } from 'api/rif-marketplace-cache/notifier/interfaces'
+import { NotifierOffersFilters } from 'models/marketItems/NotifierFilters'
 
 const NotifierSellPage: FC = () => {
   const {
@@ -40,13 +41,13 @@ const NotifierSellPage: FC = () => {
     const getOwnOffers = async (): Promise<void> => {
       setIsLoadingOffer(true)
 
-      const offersService = apis['notifier/v0/offers'] as NotifierOffersService
+      const offersService = apis['notifier/v0/offers'] as NotifierCacheAPIService
       offersService.connect(reportError)
 
       const currentOwnOffers = await offersService.fetch({
         provider: account,
-      })
-      setHasOffer(Boolean(currentOwnOffers[0]))
+      } as NotifierOffersFilters)
+      setHasOffer(Boolean(currentOwnOffers?.length))
       setIsLoadingOffer(false)
     }
 

--- a/src/components/pages/notifier/sell/NotifierSellPage.tsx
+++ b/src/components/pages/notifier/sell/NotifierSellPage.tsx
@@ -15,6 +15,7 @@ import Web3 from 'web3'
 import AppContext from 'context/App'
 import { NotifierOffersService } from 'api/rif-marketplace-cache/notifier'
 import WithLoginCard from 'components/hoc/WithLoginCard'
+import NoMultipleOffersCard from 'components/organisms/NoMultipleOffersCard'
 
 const NotifierSellPage: FC = () => {
   const {
@@ -78,8 +79,7 @@ const NotifierSellPage: FC = () => {
   if (hasOffer) {
     return (
       <CenteredPageTemplate>
-        <h1>Multiple offers is not supported yet! Please, edit your</h1>
-        <p>Please, consider editing your offer here</p>
+        <NoMultipleOffersCard service="notifier" />
       </CenteredPageTemplate>
     )
   }

--- a/src/components/pages/storage/sell/PageWrapper.tsx
+++ b/src/components/pages/storage/sell/PageWrapper.tsx
@@ -10,7 +10,7 @@ import CenteredPageTemplate from 'components/templates/CenteredPageTemplate'
 import Staking from 'components/organisms/storage/staking/Staking'
 import InfoBar from 'components/molecules/InfoBar'
 import useConfirmations from 'hooks/useConfirmations'
-import NoMultipleOffersCard from 'components/organisms/storage/sell/NoMultipleOffersCard'
+import NoMultipleOffersCard from 'components/organisms/NoMultipleOffersCard'
 import OfferCreation from 'components/organisms/storage/sell/OfferCreation'
 
 const PageWrapper: FC = () => {
@@ -52,7 +52,7 @@ const PageWrapper: FC = () => {
   if (ownOffer) {
     return (
       <CenteredPageTemplate>
-        <NoMultipleOffersCard />
+        <NoMultipleOffersCard service="storage" />
       </CenteredPageTemplate>
     )
   }

--- a/src/models/marketItems/NotifierFilters.ts
+++ b/src/models/marketItems/NotifierFilters.ts
@@ -1,4 +1,4 @@
-import { NotifierSubscriptionsTransportModel } from 'api/rif-marketplace-cache/notifier/subscriptions'
+import { SubscriptionDTO } from 'api/rif-notifier-service/models/subscriptions'
 import { SupportedFiatSymbol } from 'models/Fiat'
 import { MinMaxFilter } from 'models/Filters'
 import { SupportedTokenSymbol } from 'models/Token'
@@ -15,4 +15,8 @@ export type NotifierOffersFilters = {
     provider?: string
 }
 
-export type NotifierSubscriptionsFilters = Partial<NotifierSubscriptionsTransportModel>
+export type NotifierSubscriptionsFilters = Partial<SubscriptionDTO>
+
+export type NotifierFilters =
+    | NotifierOffersFilters
+    | NotifierSubscriptionsFilters

--- a/src/models/marketItems/NotifierFilters.ts
+++ b/src/models/marketItems/NotifierFilters.ts
@@ -10,8 +10,8 @@ type PriceFilter = MinMaxFilter & {
 export type NotifierOffersFilters = {
     size: MinMaxFilter
     price: PriceFilter
-    currency: Set<SupportedTokenSymbol>
-    channels: Set<string>
+    currency?: Set<SupportedTokenSymbol>
+    channels?: Set<string>
     provider?: string
 }
 


### PR DESCRIPTION
## Features
- [x] Add wrapper to sell page and enable to register only if check with cache that there are no offers as provider from the current account
- [x] Show spinner while fetching offers for current provider
- [x] Show "no multiple offers" card for notifier provider with redirection to your offer for edition
## Demo

https://user-images.githubusercontent.com/8449567/121590602-e24d4600-ca0e-11eb-9322-4176a1c9bb6f.mov

