### PR TITLE
feat(notifier): checks account balance before enabling payment

### DIFF
--- a/src/components/pages/notifier/buy/NotifierOfferCheckoutPage.tsx
+++ b/src/components/pages/notifier/buy/NotifierOfferCheckoutPage.tsx
@@ -31,6 +31,7 @@ import { SupportedEventType } from 'config/notifier'
 import { convertToWeiString } from 'utils/parsers'
 import { OrderItem } from 'context/Services/notifier/offers/interfaces'
 import { NotifierChannel } from 'models/marketItems/NotifierItem'
+import WithLoginCard from 'components/hoc/WithLoginCard'
 
 const buildBlockEvent = (notificationPreferences: Array<NotificationPreference>): TopicDTO => ({
   type: TOPIC_TYPES.NEW_BLOCK,
@@ -143,7 +144,10 @@ const NotifierOfferCheckoutPage: FC = () => {
   const [txOperationDone, setTxOperationDone] = useState(false)
   const [eventsAdded, setEventsAdded] = useState<NotifierEventItem[]>([])
 
-  if (!order?.item) return null
+  if (!order?.item) {
+    history.push(ROUTES.NOTIFIER.BUY.BASE)
+    return null
+  }
 
   const handleEventRemoved = (
     { id: notifierEventId }: NotifierEventItem,
@@ -161,7 +165,7 @@ const NotifierOfferCheckoutPage: FC = () => {
   }
 
   const handleOnBuy = async (): Promise<void> => {
-    if (!account) return
+    if (!account) return // wrapped with withLoginCard
     try {
       setIsProcessingTx(true)
 
@@ -265,4 +269,8 @@ const NotifierOfferCheckoutPage: FC = () => {
   )
 }
 
-export default NotifierOfferCheckoutPage
+export default WithLoginCard({
+  WrappedComponent: NotifierOfferCheckoutPage,
+  title: 'Please, connect your wallet.',
+  contentText: 'Connect your wallet in order to proceed to the checkout.',
+})

--- a/src/contracts/interfaces.ts
+++ b/src/contracts/interfaces.ts
@@ -22,13 +22,14 @@ export interface TransactionOptions {
   value?: string | number
 }
 
-export interface ERC20Contract extends PaymentWrapper{
-  approve (
-      address: string, amount: string | number, options: TransactionOptions
+export interface ERC20Contract extends PaymentWrapper {
+  approve(
+    address: string, amount: string | number, options: TransactionOptions
   ): Promise<TransactionReceipt>
 }
 
 export type Web3ErrorId = 'web3-getGasPrice'
+export type GetBalanceErrorId = 'get-balance'
 
 export type ContractErrorId =
   | Web3ErrorId
@@ -40,6 +41,7 @@ export type ContractErrorId =
   | StorageStakingContractErrorId
   | NotifierContractErrorId
   | NotifierStakingContractErrorId
+  | GetBalanceErrorId
 
 export enum TOKEN_TYPES {
   ERC20 = 'erc20',


### PR DESCRIPTION
## Features
- Wraps checkout page with login card and redirects to listing when no order was selected (for example when coming from copy paste url)
- Checks account balance before enabling payment

## Known issues
- Would be best to automatically redirect to listing without asking for the account when there is no offer selected. This improvement could be applied to the logic and flow of storage checkout as well.

## Demo

https://user-images.githubusercontent.com/8449567/121942606-0e2a3d80-cd27-11eb-8b44-5495c4c22330.mov

