### PR TITLE
feat(notifier): adds details modal to myOffers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,6 +35,7 @@
   "rules": {
     "no-restricted-syntax": "off",
     "react/prop-types": "off",
+    "react/require-default-props": "off",
     "no-unused-vars": [
       "error",
       {

--- a/src/components/organisms/notifier/details/NotifierDetailsModal.tsx
+++ b/src/components/organisms/notifier/details/NotifierDetailsModal.tsx
@@ -29,7 +29,7 @@ export type SubscriptionEventsDisplayItem = Item & {
 type Props<H extends typeof baseSubscriptionHeaders, T> = {
   headers: H
   details: T
-  events: Array<SubscriptionEventsDisplayItem>
+  events?: Array<SubscriptionEventsDisplayItem>
   onClose: (e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => void
   actions: React.ReactNode
 }
@@ -37,7 +37,7 @@ type Props<H extends typeof baseSubscriptionHeaders, T> = {
 const NotifierDetails = <H extends typeof baseSubscriptionHeaders, T, >({
   headers,
   details,
-  events,
+  events = [],
   onClose,
   actions,
 }: Props<H, T>): React.ReactElement => (

--- a/src/components/organisms/notifier/details/NotifierDetailsModal.tsx
+++ b/src/components/organisms/notifier/details/NotifierDetailsModal.tsx
@@ -1,26 +1,19 @@
-import React, { FC } from 'react'
+import React from 'react'
 import Grid from '@material-ui/core/Grid'
 import TableContainer from '@material-ui/core/TableContainer'
 import Typography from '@material-ui/core/Typography'
 import MarketplaceCell from 'components/atoms/MarketplaceCell'
-import RoundBtn from 'components/atoms/RoundBtn'
 import RifDialog from 'components/organisms/RifDialog'
 import Marketplace from 'components/templates/marketplace/Marketplace'
 import { Item } from 'models/Market'
-import { logNotImplemented } from 'utils/utils'
 
-const subscriptionHeaders = {
+export const baseSubscriptionHeaders = {
   id: 'Subscription ID',
-  provider: 'Provider',
   amount: 'Notifications',
   channels: 'Channels',
   price: 'Price',
   expDate: 'Expiration Date',
-}
-
-export type SubscriptionDetails = {
-    [K in keyof typeof subscriptionHeaders]: string
-  }
+} as const
 
 const eventsHeaders = {
   name: 'Name',
@@ -33,17 +26,21 @@ export type SubscriptionEventsDisplayItem = Item & {
     [K in keyof typeof eventsHeaders]: React.ReactElement
   }
 
-type Props = {
-  details: SubscriptionDetails
-  events?: Array<SubscriptionEventsDisplayItem>
+type Props<H extends typeof baseSubscriptionHeaders, T> = {
+  headers: H
+  details: T
+  events: Array<SubscriptionEventsDisplayItem>
   onClose: (e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => void
+  actions: React.ReactNode
 }
 
-const NotifierDetails: FC<Props> = ({
+const NotifierDetails = <H extends typeof baseSubscriptionHeaders, T, >({
+  headers,
   details,
   events,
   onClose,
-}) => (
+  actions,
+}: Props<H, T>): React.ReactElement => (
   <RifDialog
     open={Boolean(details)}
     onClose={onClose}
@@ -77,7 +74,7 @@ const NotifierDetails: FC<Props> = ({
         sm={6}
       >
         {
-          Object.keys(subscriptionHeaders).map((detailsHeader) => (
+          Object.keys(headers).map((detailsHeader) => (
             <Grid
               key={detailsHeader}
               item
@@ -87,7 +84,7 @@ const NotifierDetails: FC<Props> = ({
             >
               <Grid item xs={6}>
                 <MarketplaceCell style={{ textAlign: 'right' }}>
-                  {String(subscriptionHeaders[detailsHeader]).toUpperCase() }
+                  {String(headers[detailsHeader]).toUpperCase() }
                 </MarketplaceCell>
               </Grid>
               <Grid item xs={6}>
@@ -125,7 +122,7 @@ const NotifierDetails: FC<Props> = ({
         style={{ paddingTop: '-16px' }}
       >
         <Grid item>
-          {events?.length && (
+          {Boolean(events.length) && (
           <TableContainer>
             <Marketplace
               isLoading={false}
@@ -135,7 +132,7 @@ const NotifierDetails: FC<Props> = ({
           </TableContainer>
           )}
           {
-            !events?.length && (
+            !events.length && (
               <MarketplaceCell>
                 There seem to be no events here.
               </MarketplaceCell>
@@ -153,12 +150,10 @@ const NotifierDetails: FC<Props> = ({
         alignItems="center"
       >
         <Grid item>
-          <RoundBtn onClick={logNotImplemented('cancel handle')}>
-            Cancel plan
-          </RoundBtn>
+          {actions}
         </Grid>
       </Grid>
     </Grid>
   </RifDialog>
-)
+  )
 export default NotifierDetails

--- a/src/components/organisms/notifier/details/utils.tsx
+++ b/src/components/organisms/notifier/details/utils.tsx
@@ -3,8 +3,8 @@ import {
   EventParam, EVENT_PARAM_TYPES, SubscriptionEvent, TopicParamType,
 } from 'api/rif-marketplace-cache/notifier/subscriptions/models'
 import MarketplaceCell from 'components/atoms/MarketplaceCell'
-import { SubscriptionEventsDisplayItem } from 'components/organisms/notifier/mypurchase/NotifierDetailsModal'
 import RifAddress from 'components/molecules/RifAddress'
+import { SubscriptionEventsDisplayItem } from './NotifierDetailsModal'
 
 export const getTopicParamValue = (
   topicParams: Array<EventParam>,

--- a/src/components/organisms/notifier/myoffers/details.ts
+++ b/src/components/organisms/notifier/myoffers/details.ts
@@ -2,7 +2,7 @@ import { baseSubscriptionHeaders } from '../details/NotifierDetailsModal'
 
 export const subscriptionHeaders = {
   ...baseSubscriptionHeaders,
-  provider: 'Provider',
+  customer: 'Customer',
 } as const
 
 export type SubscriptionDetails = {

--- a/src/components/organisms/notifier/mypurchase/details.ts
+++ b/src/components/organisms/notifier/mypurchase/details.ts
@@ -1,0 +1,10 @@
+import { baseSubscriptionHeaders } from '../details/NotifierDetailsModal'
+
+export const subscriptionHeaders = {
+  ...baseSubscriptionHeaders,
+  provider: 'Provider',
+}
+
+export type SubscriptionDetails = {
+    [K in keyof typeof subscriptionHeaders]: string
+  }

--- a/src/components/pages/notifier/myoffers/mapActiveContracts.tsx
+++ b/src/components/pages/notifier/myoffers/mapActiveContracts.tsx
@@ -76,7 +76,7 @@ const mapActiveContracts = <T extends Function, U extends Function>(
               children: 'Withdraw',
             }, {
               id: `view_${id}`,
-              handleSelect: (): void => onView(),
+              handleSelect: (): void => onView(id),
               children: 'View',
             },
           ]}

--- a/src/components/pages/notifier/mypurchase/NotifierMyPurchasePage.tsx
+++ b/src/components/pages/notifier/mypurchase/NotifierMyPurchasePage.tsx
@@ -12,10 +12,6 @@ import RoundedCard from 'components/atoms/RoundedCard'
 import WithLoginCard from 'components/hoc/WithLoginCard'
 import InfoBar from 'components/molecules/InfoBar'
 import MyPurchasesHeader from 'components/molecules/MyPurchasesHeader'
-import NotifierDetails, {
-  SubscriptionDetails,
-  SubscriptionEventsDisplayItem,
-} from 'components/organisms/notifier/mypurchase/NotifierDetailsModal'
 import PurchasesTable, { MySubscription } from 'components/organisms/notifier/mypurchase/PurchasesTable'
 import CenteredPageTemplate from 'components/templates/CenteredPageTemplate'
 import AppContext, { AppContextProps } from 'context/App'
@@ -31,8 +27,11 @@ import { getShortDateString } from 'utils/dateUtils'
 import { shortChecksumAddress } from 'utils/stringUtils'
 import { getFiatPrice } from 'utils/tokenUtils'
 import { logNotImplemented } from 'utils/utils'
+import { SubscriptionDetails, subscriptionHeaders } from 'components/organisms/notifier/mypurchase/details'
+import NotifierDetails, { SubscriptionEventsDisplayItem } from 'components/organisms/notifier/details/NotifierDetailsModal'
+import RoundBtn from 'components/atoms/RoundBtn'
 import mapMyPurchases from './mapMyPurchases'
-import { eventDisplayItemIterator } from './utils'
+import { eventDisplayItemIterator } from '../../../organisms/notifier/details/utils'
 
 const useTitleStyles = makeStyles(() => ({
   root: {
@@ -169,9 +168,15 @@ const NotifierMyPurchasePage: FC = () => {
         {subscriptionDetails
           && (
             <NotifierDetails
+              headers={subscriptionHeaders}
               details={subscriptionDetails}
-              events={subscriptionEvents}
+              events={subscriptionEvents || []}
               onClose={onModalClose}
+              actions={(
+                <RoundBtn onClick={logNotImplemented('cancel handle')}>
+                  Cancel plan
+                </RoundBtn>
+)}
             />
           )}
       </>


### PR DESCRIPTION
Refactors existing details model on "my purchases" page to be reused by "my offers" page.
Adds this to the "my offers" page.

Resolves https://rsklabs.atlassian.net/browse/RMKT-625


https://user-images.githubusercontent.com/36888576/122078611-a04c4780-cdf4-11eb-96d6-0aa50c636c16.mov

