### PR TITLE
feat(notifier): adds renew subscription

### DIFF
--- a/src/api/rif-marketplace-cache/notifier/subscriptions/api.ts
+++ b/src/api/rif-marketplace-cache/notifier/subscriptions/api.ts
@@ -22,6 +22,7 @@ export const mapFromTransport = ({
   expirationDate,
   price,
   rateId,
+  provider,
   providerId,
   topics,
   ...subscription
@@ -30,7 +31,7 @@ export const mapFromTransport = ({
   expirationDate: new Date(expirationDate),
   price: parseToBigDecimal(price),
   token: getSupportedTokenByName(rateId as SupportedTokenSymbol),
-  providerId,
+  provider: { url: provider.url, provider: providerId },
   events: topics,
   ...subscription,
 })

--- a/src/api/rif-marketplace-cache/notifier/subscriptions/models.ts
+++ b/src/api/rif-marketplace-cache/notifier/subscriptions/models.ts
@@ -1,4 +1,4 @@
-import { SupportedEventChannel } from 'config/notifier'
+import { TopicDTO } from 'api/rif-notifier-service/models/subscriptions'
 import { PlanDTO } from '../offers/models'
 
 export const EVENT_TYPES = {
@@ -17,18 +17,6 @@ export const EVENT_PARAM_TYPES = {
 } as const
 
 export type TopicParamType = keyof typeof EVENT_PARAM_TYPES
-
-export type EventParam = {
-  type: TopicParamType
-  value: string
-  valueType: string
-}
-
-export type SubscriptionEvent = {
-  notificationPreferences: SupportedEventChannel | Array<SupportedEventChannel>
-  type: SubscriptionEventType
-  topicParams: Array<EventParam>
-}
 
 export const SUBSCRIPTION_STATUS = {
   ACTIVE: 'ACTIVE',
@@ -53,7 +41,7 @@ export type SubscriptionDTO = {
   previousSubscription: string
   expirationDate: Date
   consumer: string
-  topics: Array<SubscriptionEvent>
+  topics: Array<TopicDTO>
   paid: boolean
   price: string
   rateId: string

--- a/src/api/rif-notifier-service/models/subscriptions.ts
+++ b/src/api/rif-notifier-service/models/subscriptions.ts
@@ -45,7 +45,7 @@ export type NotificationPreference = {
 export type TopicDTO = {
   notificationPreferences: Array<NotificationPreference>
   type: TopicType
-  topicParams: Array<TopicParams>
+  topicParams?: Array<TopicParams>
 }
 
 export const SUBSCRIPTION_STATUSES = {

--- a/src/api/rif-notifier-service/models/subscriptions.ts
+++ b/src/api/rif-notifier-service/models/subscriptions.ts
@@ -45,7 +45,7 @@ export type NotificationPreference = {
 export type TopicDTO = {
   notificationPreferences: Array<NotificationPreference>
   type: TopicType
-  topicParams?: Array<TopicParams>
+  topicParams: Array<TopicParams>
 }
 
 export const SUBSCRIPTION_STATUSES = {

--- a/src/api/rif-notifier-service/renewSubscription.ts
+++ b/src/api/rif-notifier-service/renewSubscription.ts
@@ -1,0 +1,43 @@
+import { logNotImplemented } from 'utils/utils'
+import { NotifierAPIService, NotifierResponse } from './interfaces'
+import { NOTIFIER_RESPONSE_STATUSES } from './models/response'
+import { SubscribeToPlanDTO, SubscribeToPlanResponseDTO } from './models/subscriptions'
+
+type SubscribeToPlanResponse = NotifierResponse<SubscribeToPlanResponseDTO>
+
+export const address = 'renewSubscription' as const
+export default class RenewSubscriptionService
+  extends NotifierAPIService {
+  path = address
+
+  _fetch = (): Promise<void> => Promise.resolve(logNotImplemented('find')())
+
+  _create = <SubscribeToPlanDTO, SubscribeToPlanResponse>
+    (
+      subscriptionData: SubscribeToPlanDTO,
+      query,
+  ):
+    Promise<SubscribeToPlanResponse> => this.service.create(subscriptionData, query)
+
+  renewSubscription = async (
+    subscriptionData: SubscribeToPlanDTO,
+    previousSubscriptionHash: string,
+  ):
+    Promise<SubscribeToPlanResponseDTO> => {
+    const query = { previousSubscriptionHash }
+
+    const response: SubscribeToPlanResponse = await this.create(
+      subscriptionData, { query },
+    )
+    const { status, content } = response
+
+    if (status !== NOTIFIER_RESPONSE_STATUSES.OK) {
+      this.errorReporter({
+        error: new Error('Subscription Renew Error'),
+        text: 'Error renewing subscription',
+        id: 'service-post',
+      })
+    }
+    return content
+  }
+}

--- a/src/api/rif-notifier-service/subscriptionUtils.ts
+++ b/src/api/rif-notifier-service/subscriptionUtils.ts
@@ -16,6 +16,7 @@ const buildBlockEvent = (
 ): TopicDTO => ({
   type: TOPIC_TYPES.NEW_BLOCK,
   notificationPreferences,
+  topicParams: [],
 })
 
 const buildContractEvent = (
@@ -94,7 +95,7 @@ type SubscriptionOrderItem = Pick<OrderItem, 'url' | 'planId' | 'value'> & {
 
 export const buildSubscribeToPlanDTO = (
   item: SubscriptionOrderItem,
-  notifierEventItems: Array<NotifierEventItem>,
+  topics: Array<TopicDTO>,
   account: string,
 ): SubscribeToPlanDTO => {
   const {
@@ -102,8 +103,6 @@ export const buildSubscribeToPlanDTO = (
     planId: subscriptionPlanId,
     value: price,
   } = item
-
-  const topics = buildTopicsDTOFrom(notifierEventItems)
 
   return {
     subscriptionPlanId: Number(subscriptionPlanId),
@@ -118,8 +117,7 @@ export const searchPendingSubscription = (
   account: string,
   item: SubscriptionOrderItem,
   reportError: (e: UIError) => void,
-):
-  Promise<SubscriptionSummary | undefined> => {
+): Promise<SubscriptionSummary | undefined> => {
   const { url: providerUrl, planId } = item
   const subscriptionService = new SubscriptionService(providerUrl)
   subscriptionService.connect(reportError)
@@ -133,7 +131,7 @@ export const createPendingSubscription = (
 ): Promise<SubscribeToPlanResponseDTO> => {
   const { url: providerUrl } = item
   const subscribeToPlanDTO = buildSubscribeToPlanDTO(
-    item, notifierEventItems, account,
+    item, buildTopicsDTOFrom(notifierEventItems), account,
   )
 
   const subscribeToPlanService = new SubscribeToPlanService(providerUrl)

--- a/src/components/organisms/notifier/details/utils.tsx
+++ b/src/components/organisms/notifier/details/utils.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import {
-  EventParam, EVENT_PARAM_TYPES, SubscriptionEvent, TopicParamType,
+  EVENT_PARAM_TYPES, TopicParamType,
 } from 'api/rif-marketplace-cache/notifier/subscriptions/models'
 import MarketplaceCell from 'components/atoms/MarketplaceCell'
 import RifAddress from 'components/molecules/RifAddress'
+import { TopicDTO, TopicParams } from 'api/rif-notifier-service/models/subscriptions'
 import { SubscriptionEventsDisplayItem } from './NotifierDetailsModal'
 
 export const getTopicParamValue = (
-  topicParams: Array<EventParam>,
+  topicParams: Array<TopicParams>,
   paramType: TopicParamType,
 ): string => topicParams.find(
   ({ type }) => type === paramType,
@@ -15,7 +16,7 @@ export const getTopicParamValue = (
 
 export const eventDisplayItemIterator = ({
   notificationPreferences, topicParams, type: eventType,
-}: SubscriptionEvent): SubscriptionEventsDisplayItem => {
+}: TopicDTO): SubscriptionEventsDisplayItem => {
   const nameValue = getTopicParamValue(
     topicParams, EVENT_PARAM_TYPES.EVENT_NAME,
   )

--- a/src/components/organisms/notifier/details/utils.tsx
+++ b/src/components/organisms/notifier/details/utils.tsx
@@ -17,7 +17,7 @@ export const getTopicParamValue = (
 export const eventDisplayItemIterator = ({
   notificationPreferences, topicParams, type: eventType,
 }: TopicDTO): SubscriptionEventsDisplayItem => {
-  const nameValue = getTopicParamValue(
+  const nameValue = topicParams && getTopicParamValue(
     topicParams, EVENT_PARAM_TYPES.EVENT_NAME,
   )
   const name = (
@@ -25,7 +25,7 @@ export const eventDisplayItemIterator = ({
       {nameValue || eventType}
     </MarketplaceCell>
   )
-  const contractAddress = getTopicParamValue(
+  const contractAddress = topicParams && getTopicParamValue(
     topicParams, EVENT_PARAM_TYPES.CONTRACT_ADDRESS,
   )
   const contract = contractAddress ? (

--- a/src/components/organisms/notifier/mypurchase/PurchasesTable.tsx
+++ b/src/components/organisms/notifier/mypurchase/PurchasesTable.tsx
@@ -26,7 +26,6 @@ export type MySubscription = Item & {
 
 type Props = {
   items: Array<MySubscription>
-  isTableLoading: boolean
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -35,7 +34,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }))
 
-const PurchasesTable: FC<Props> = ({ items: subscriptions, isTableLoading }) => {
+const PurchasesTable: FC<Props> = ({ items: subscriptions }) => {
   const classes = useStyles()
 
   if (!subscriptions.length) {
@@ -54,7 +53,7 @@ const PurchasesTable: FC<Props> = ({ items: subscriptions, isTableLoading }) => 
     <TableContainer>
       <Marketplace
         headers={headers}
-        isLoading={isTableLoading}
+        isLoading={false}
         items={subscriptions}
       />
     </TableContainer>

--- a/src/components/pages/notifier/buy/NotifierOfferCheckoutPage.tsx
+++ b/src/components/pages/notifier/buy/NotifierOfferCheckoutPage.tsx
@@ -127,7 +127,7 @@ const NotifierOfferCheckoutPage: FC = () => {
       reportError({
         error,
         id: 'contract-notifier',
-        text: customMessage || 'Could not complete the order}',
+        text: customMessage || 'Could not complete the order',
       })
     } finally {
       setIsProcessingTx(false)

--- a/src/components/pages/notifier/buy/NotifierOfferCheckoutPage.tsx
+++ b/src/components/pages/notifier/buy/NotifierOfferCheckoutPage.tsx
@@ -87,7 +87,7 @@ const NotifierOfferCheckoutPage: FC = () => {
         url,
       } = item
 
-      const { symbol } = token
+      const { symbol, tokenAddress } = token
 
       const {
         hash: subscriptionHash, signature,
@@ -104,7 +104,7 @@ const NotifierOfferCheckoutPage: FC = () => {
             providerAddress,
             signature,
             amount,
-            token,
+            tokenAddress,
           },
           {
             from: account,

--- a/src/components/pages/notifier/mypurchase/NotifierMyPurchasePage.tsx
+++ b/src/components/pages/notifier/mypurchase/NotifierMyPurchasePage.tsx
@@ -2,11 +2,9 @@ import { makeStyles } from '@material-ui/core/styles'
 import Typography from '@material-ui/core/Typography'
 import {
   shortenString,
-  theme, Web3Store,
+  theme, Web3Store, Spinner,
 } from '@rsksmart/rif-ui'
 import { notifierSubscriptionsAddress } from 'api/rif-marketplace-cache/notifier/subscriptions'
-import GridColumn from 'components/atoms/GridColumn'
-import GridItem from 'components/atoms/GridItem'
 import GridRow from 'components/atoms/GridRow'
 import RoundedCard from 'components/atoms/RoundedCard'
 import WithLoginCard from 'components/hoc/WithLoginCard'
@@ -78,7 +76,7 @@ const NotifierMyPurchasePage: FC = () => {
     setSubscriptionEvents,
   ] = useState<Array<SubscriptionEventsDisplayItem>>()
 
-  const [isTableLoading, setIsTableLoading] = useState<boolean>()
+  const [isLoadingData, setIsLoadingData] = useState<boolean>(true)
 
   const numberOfConfs = useConfirmations(
     ['NOTIFIER_CREATE_SUBSCRIPTION'],
@@ -87,7 +85,7 @@ const NotifierMyPurchasePage: FC = () => {
 
   useEffect(() => {
     if (account && subscriptionsApi) {
-      setIsTableLoading(true)
+      setIsLoadingData(true)
       subscriptionsApi.connect(reportError)
       subscriptionsApi.fetch({
         consumer: account,
@@ -102,7 +100,7 @@ const NotifierMyPurchasePage: FC = () => {
           error,
         })))
         .finally(() => {
-          setIsTableLoading(false)
+          setIsLoadingData(false)
         })
     }
   }, [subscriptionsApi, account, reportError])
@@ -193,24 +191,23 @@ const NotifierMyPurchasePage: FC = () => {
       <>
         <MyPurchasesHeader />
         <RoundedCard color="secondary">
-          <GridColumn>
-            <GridItem>
-              <Typography
-                gutterBottom
-                color="primary"
-                variant="subtitle1"
-                classes={titleStyles}
-              >
-                Active plans
-              </Typography>
-            </GridItem>
-            <GridRow>
-              <PurchasesTable
-                items={items}
-                isTableLoading={Boolean(isTableLoading)}
-              />
-            </GridRow>
-          </GridColumn>
+          <GridRow>
+            <Typography
+              gutterBottom
+              color="primary"
+              variant="subtitle1"
+              classes={titleStyles}
+            >
+              Active plans
+            </Typography>
+          </GridRow>
+          <GridRow>
+            {
+              isLoadingData
+                ? <Spinner />
+                : <PurchasesTable items={items} />
+            }
+          </GridRow>
         </RoundedCard>
         {subscriptionDetails
           && (

--- a/src/components/pages/notifier/mypurchase/NotifierMyPurchasePage.tsx
+++ b/src/components/pages/notifier/mypurchase/NotifierMyPurchasePage.tsx
@@ -32,7 +32,6 @@ import { eventDisplayItemIterator } from 'components/organisms/notifier/details/
 import { SUBSCRIPTION_STATUSES } from 'api/rif-notifier-service/models/subscriptions'
 import { buildSubscribeToPlanDTO } from 'api/rif-notifier-service/subscriptionUtils'
 import RenewSubscriptionService from 'api/rif-notifier-service/renewSubscription'
-import Logger from 'utils/Logger'
 import ProgressOverlay from 'components/templates/ProgressOverlay'
 import ROUTES from 'routes'
 import NotifierContract from 'contracts/notifier/Notifier'
@@ -167,7 +166,6 @@ const NotifierMyPurchasePage: FC = () => {
         plan: { planId },
         price,
         token: { symbol: tokenSymbol, tokenAddress },
-        events,
         provider: { provider: providerAddress, url: providerUrl },
       } = subscription
 
@@ -175,7 +173,7 @@ const NotifierMyPurchasePage: FC = () => {
         {
           value: price, symbol: tokenSymbol, planId, url: providerUrl,
         },
-        events,
+        [],
         account, // wrapped with login card
       )
 
@@ -184,14 +182,13 @@ const NotifierMyPurchasePage: FC = () => {
       const response = await renewSubscriptionService.renewSubscription(
         subscribeToPlanDTO, subscriptionHash,
       )
-      Logger.getInstance().debug('response', { response })
 
-      const { signature } = response
+      const { hash: renewalHash, signature } = response
 
       const purchaseReceipt = await NotifierContract.getInstance(web3 as Web3)
         .createSubscription(
           {
-            subscriptionHash,
+            subscriptionHash: renewalHash,
             providerAddress,
             signature,
             amount: price,

--- a/src/components/pages/notifier/mypurchase/NotifierMyPurchasePage.tsx
+++ b/src/components/pages/notifier/mypurchase/NotifierMyPurchasePage.tsx
@@ -122,18 +122,19 @@ const NotifierMyPurchasePage: FC = () => {
 
     const {
       id,
-      providerId,
       notificationBalance,
       plan: { channels },
       expirationDate,
       price,
       token: { symbol: tokenSymbol },
       events,
+      provider,
     } = subscription
+    const { provider: providerAddress } = provider
 
     const viewItem: typeof subscriptionDetails = {
       id: shortenString(id),
-      provider: shortChecksumAddress(providerId),
+      provider: shortChecksumAddress(providerAddress),
       amount: String(notificationBalance),
       channels: channels?.map(({ name }) => name).join(',') || '',
       expDate: getShortDateString(expirationDate),

--- a/src/components/pages/notifier/mypurchase/mapMyPurchases.tsx
+++ b/src/components/pages/notifier/mypurchase/mapMyPurchases.tsx
@@ -51,7 +51,7 @@ const mapMyPurchases = <V extends Function, R extends Function>(
     return {
       id,
       subId: <MarketplaceAddressCell value={id} />,
-      provider: <MarketplaceAddressCell value={providerAddress || ''} />,
+      provider: <MarketplaceAddressCell value={providerAddress} />,
       notifications: (
         <NotificationsBalance
           balance={notificationBalance}

--- a/src/components/pages/notifier/mypurchase/mapMyPurchases.tsx
+++ b/src/components/pages/notifier/mypurchase/mapMyPurchases.tsx
@@ -29,22 +29,23 @@ const mapMyPurchases = <V extends Function, R extends Function>(
   }) => ({
     id,
     token,
-    providerId,
     plan,
     notificationBalance,
     expirationDate,
     price,
+    provider,
   }: NotifierSubscriptionItem):
     MySubscription => {
     const { rate, displayName } = crypto?.[token.symbol]
       || { rate: 0, displayName: '' }
 
     const expType = getExpirationType(plan)
+    const { provider: providerAddress } = provider
 
     return {
       id,
       subId: <MarketplaceAddressCell value={id} />,
-      provider: <MarketplaceAddressCell value={providerId} />,
+      provider: <MarketplaceAddressCell value={providerAddress || ''} />,
       notifications: (
         <NotificationsBalance
           balance={notificationBalance}

--- a/src/components/pages/notifier/mypurchase/mapMyPurchases.tsx
+++ b/src/components/pages/notifier/mypurchase/mapMyPurchases.tsx
@@ -8,6 +8,7 @@ import { ExchangeRate } from 'context/Market/interfaces'
 import MarketplaceAddressCell from 'components/molecules/MarketplaceAddressCell'
 import ExpirationDate, { SubscriptionExpirationType } from 'components/molecules/ExpirationDate'
 import { PlanDTO, PLAN_STATUS } from 'api/rif-marketplace-cache/notifier/offers/models'
+import { SUBSCRIPTION_STATUSES } from 'api/rif-notifier-service/models/subscriptions'
 
 const EXPIRATION_WARNING_TRIGGER = 5
 
@@ -34,6 +35,7 @@ const mapMyPurchases = <V extends Function, R extends Function>(
     expirationDate,
     price,
     provider,
+    status,
   }: NotifierSubscriptionItem):
     MySubscription => {
     const { rate, displayName } = crypto?.[token.symbol]
@@ -41,6 +43,10 @@ const mapMyPurchases = <V extends Function, R extends Function>(
 
     const expType = getExpirationType(plan)
     const { provider: providerAddress } = provider
+    const canRenew = (
+      status === SUBSCRIPTION_STATUSES.COMPLETED
+      || status === SUBSCRIPTION_STATUSES.EXPIRED
+    )
 
     return {
       id,
@@ -70,7 +76,7 @@ const mapMyPurchases = <V extends Function, R extends Function>(
         <MarketplaceActionsCell
           actions={[
             {
-              disabled: expType === 'blocked',
+              disabled: !canRenew,
               id: `renew_${id}`,
               handleSelect: (): void => onRenew(id),
               children: 'Renew',

--- a/src/components/pages/notifier/mypurchase/mapMyPurchases.tsx
+++ b/src/components/pages/notifier/mypurchase/mapMyPurchases.tsx
@@ -35,9 +35,9 @@ const mapMyPurchases = <V extends Function, R extends Function>(
     expirationDate,
     price,
   }: NotifierSubscriptionItem):
-  MySubscription => {
+    MySubscription => {
     const { rate, displayName } = crypto?.[token.symbol]
-    || { rate: 0, displayName: '' }
+      || { rate: 0, displayName: '' }
 
     const expType = getExpirationType(plan)
 
@@ -71,7 +71,7 @@ const mapMyPurchases = <V extends Function, R extends Function>(
             {
               disabled: expType === 'blocked',
               id: `renew_${id}`,
-              handleSelect: (): void => onRenew(),
+              handleSelect: (): void => onRenew(id),
               children: 'Renew',
             }, {
               id: `view_${id}`,

--- a/src/contracts/interfaces.ts
+++ b/src/contracts/interfaces.ts
@@ -82,5 +82,5 @@ export type CreateSubscriptionParams = {
   providerAddress: string
   signature: string
   amount: Big
-  token: SupportedToken
+  tokenAddress: string
 }

--- a/src/contracts/notifier/Notifier.ts
+++ b/src/contracts/notifier/Notifier.ts
@@ -98,7 +98,7 @@ class NotifierContract extends ContractWithTokens {
       subscriptionHash,
       signature,
       amount,
-      token: { tokenAddress },
+      tokenAddress,
     } = data
     const weiAmount = convertToWeiString(amount)
     const createSubsTx = this.contract.methods.createSubscription(

--- a/src/models/marketItems/NotifierItem.ts
+++ b/src/models/marketItems/NotifierItem.ts
@@ -1,8 +1,9 @@
 import { Item } from 'models/Market'
 import Big from 'big.js'
 import { SupportedToken } from 'contracts/interfaces'
-import { SubscriptionDTO, SubscriptionEvent } from 'api/rif-marketplace-cache/notifier/subscriptions/models'
+import { SubscriptionDTO } from 'api/rif-marketplace-cache/notifier/subscriptions/models'
 import { SupportedEventType, SupportedEventChannel } from 'config/notifier'
+import { TopicDTO } from 'api/rif-notifier-service/models/subscriptions'
 
 export type PriceOption = {
     token: SupportedToken
@@ -31,7 +32,7 @@ export type NotifierSubscriptionItem = Item & Omit<SubscriptionDTO,
     price: Big
     provider: Provider
     token: SupportedToken
-    events: Array<SubscriptionEvent>
+    events: Array<TopicDTO>
 }
 
 export type NotifierChannel = {

--- a/src/models/marketItems/NotifierItem.ts
+++ b/src/models/marketItems/NotifierItem.ts
@@ -28,7 +28,7 @@ export type NotifierPlan = Item & Provider & {
 export type NotifierOfferItem = NotifierPlan
 
 export type NotifierSubscriptionItem = Item & Omit<SubscriptionDTO,
-'hash' | 'price' | 'rateId' | 'topics'> & {
+'hash' | 'price' | 'rateId' | 'providerId' | 'topics'> & {
     price: Big
     provider: Provider
     token: SupportedToken


### PR DESCRIPTION
## Features
- adds renew subscription feature. Enabled only on expired or completed subscriptions
  - interacts with notifier service to renew and get the hash
  - once we have the has, interacts with the SC to renew
- fixes spinner while loading purchased subscriptions. Before, when there were no subscriptions it was showing "No purchases yet" and then the spinner. With this change it shows the spinner until we know if there are pending subscriptions or not.

## Demo
Note: the appearance of the new subscription takes a bit longer because notifier service requires more confirmed blocks than cache.


https://user-images.githubusercontent.com/8449567/124195328-9b4bf100-daa0-11eb-9b2e-437bfe92ab5e.mov

