### PR TITLE
fix(staking): fixes styles in card - usd value was out of its wrapper

### DIFF
--- a/src/components/organisms/notifier/Staking.tsx
+++ b/src/components/organisms/notifier/Staking.tsx
@@ -135,6 +135,7 @@ const Staking: FC<Props> = ({ isEnabled }) => {
         totalStakedUSD={totalStakedUSD}
         onDeposit={handleDeposit}
         onWithdraw={handleWithdraw}
+        bringToFront
       />
       <ProgressOverlay
         title={txInProgressMessage}

--- a/src/components/organisms/staking/StakingTemplate.tsx
+++ b/src/components/organisms/staking/StakingTemplate.tsx
@@ -32,7 +32,12 @@ const useStyles = makeStyles((theme: Theme) => ({
   root: {
     display: 'flex',
     justifyContent: 'flex-end',
-    width: '50%',
+    [theme.breakpoints.up('md')]: {
+      width: '60%',
+    },
+    [theme.breakpoints.down('md')]: {
+      width: '100%',
+    },
     right: 0,
     position: 'absolute',
   },
@@ -40,7 +45,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     zIndex: 99,
   },
   cardWrapper: {
-    maxWidth: '550px',
+    maxWidth: '600px',
     width: '100%',
   },
   infoContainer: {


### PR DESCRIPTION
## Fixes
- USD value was out of its wrapper for values > 8 digits.
- zIndex was not applied in notifier page, causing the edit button to be present in the card.

## Screenshots
### Before
<img width="460" alt="Screen Shot 2021-06-18 at 16 27 03" src="https://user-images.githubusercontent.com/8449567/122608173-244f3b00-d052-11eb-9151-7a2134522d27.png">

### After
<img width="838" alt="Screen Shot 2021-06-18 at 16 17 37" src="https://user-images.githubusercontent.com/8449567/122608190-2b764900-d052-11eb-9502-edb69de0036c.png">
