### PR TITLE
fix: uses the absolute value of exponent of price

### DIFF
--- a/src/utils/priceUtils.ts
+++ b/src/utils/priceUtils.ts
@@ -15,7 +15,7 @@ export const toPrecision = (
   const precision = PRICE_PRECISIONS[precisionType]
 
   const bigPrice = Big(price)
-  const exponent = bigPrice.e
+  const exponent = Math.abs(bigPrice.e)
 
   const fixTo = bigPrice.lt(1) && exponent > precision ? exponent : precision
 


### PR DESCRIPTION
Fixes issue where for a very small numbers only 0.00 would show.

![Screenshot 2021-06-21 at 14 56 46](https://user-images.githubusercontent.com/36888576/122774253-f14eb680-d2a0-11eb-9d05-5c2ec1571042.png)
