### PR TITLE
fix(notifier): uses providerId instead of object to get address

### DIFF
--- a/src/api/rif-marketplace-cache/notifier/subscriptions/api.ts
+++ b/src/api/rif-marketplace-cache/notifier/subscriptions/api.ts
@@ -30,7 +30,7 @@ export const mapFromTransport = ({
   expirationDate: new Date(expirationDate),
   price: parseToBigDecimal(price),
   token: getSupportedTokenByName(rateId as SupportedTokenSymbol),
-  provider: providerId,
+  providerId,
   events: topics,
   ...subscription,
 })

--- a/src/components/pages/notifier/mypurchase/NotifierMyPurchasePage.tsx
+++ b/src/components/pages/notifier/mypurchase/NotifierMyPurchasePage.tsx
@@ -119,7 +119,7 @@ const NotifierMyPurchasePage: FC = () => {
 
     const {
       id,
-      provider,
+      providerId,
       notificationBalance,
       plan: { channels },
       expirationDate,
@@ -130,7 +130,7 @@ const NotifierMyPurchasePage: FC = () => {
 
     const viewItem: typeof subscriptionDetails = {
       id: shortenString(id),
-      provider: shortChecksumAddress(provider),
+      provider: shortChecksumAddress(providerId),
       amount: String(notificationBalance),
       channels: channels?.map(({ name }) => name).join(',') || '',
       expDate: getShortDateString(expirationDate),

--- a/src/components/pages/notifier/mypurchase/mapMyPurchases.tsx
+++ b/src/components/pages/notifier/mypurchase/mapMyPurchases.tsx
@@ -29,7 +29,7 @@ const mapMyPurchases = <V extends Function, R extends Function>(
   }) => ({
     id,
     token,
-    provider,
+    providerId,
     plan,
     notificationBalance,
     expirationDate,
@@ -44,7 +44,7 @@ const mapMyPurchases = <V extends Function, R extends Function>(
     return {
       id,
       subId: <MarketplaceAddressCell value={id} />,
-      provider: <MarketplaceAddressCell value={provider} />,
+      provider: <MarketplaceAddressCell value={providerId} />,
       notifications: (
         <NotificationsBalance
           balance={notificationBalance}

--- a/src/models/marketItems/NotifierItem.ts
+++ b/src/models/marketItems/NotifierItem.ts
@@ -27,8 +27,7 @@ export type NotifierPlan = Item & Provider & {
 export type NotifierOfferItem = NotifierPlan
 
 export type NotifierSubscriptionItem = Item & Omit<SubscriptionDTO,
-'hash' | 'price' | 'rateId' | 'providerId' | 'topics'> & {
-    provider: string
+'hash' | 'price' | 'rateId' | 'topics'> & {
     price: Big
     token: SupportedToken
     events: Array<SubscriptionEvent>


### PR DESCRIPTION
Uses `providerId` to calculate checksum address. Before was using provider object.