### PR TITLE
fix(notifier): uses plan.id myOffers subscriptions

### DIFF
--- a/src/components/pages/notifier/myoffers/mapActiveContracts.tsx
+++ b/src/components/pages/notifier/myoffers/mapActiveContracts.tsx
@@ -22,7 +22,7 @@ export type ActiveContractItem = Item & {
   }
 
 const mapActiveContracts = <T extends Function, U extends Function>(
-  myCustomers: NotifierSubscriptionItem[],
+  myCustomers: NotifierSubscriptionItem[] = [],
   { id: offerId, limit }: Pick<NotifierOfferItem, 'id' | 'limit'>,
   { currentFiat: { displayName }, crypto }: {
     currentFiat: BaseFiat
@@ -33,7 +33,7 @@ const mapActiveContracts = <T extends Function, U extends Function>(
       onView: U
     },
 ): Array<ActiveContractItem> => myCustomers
-    .filter(({ plan: { planId } }) => String(planId) === offerId)
+    .filter(({ plan: { id } }) => String(id) === offerId)
     .map<ActiveContractItem>(({
       id,
       consumer,


### PR DESCRIPTION
Resolves https://rsklabs.atlassian.net/browse/RMKT-823
by changing `planId` to `plan.id` when mapping subscriptions to plans, as this was changed recently