### PR TITLE
feat(notifier): shows latest own subs only

### DIFF
--- a/src/components/pages/notifier/mypurchase/NotifierMyPurchasePage.tsx
+++ b/src/components/pages/notifier/mypurchase/NotifierMyPurchasePage.tsx
@@ -102,7 +102,19 @@ const NotifierMyPurchasePage: FC = () => {
           $ne: SUBSCRIPTION_STATUSES.PENDING,
         },
       })
-        .then(setSubscriptions)
+        .then((incomingSubscriptions: Array<NotifierSubscriptionItem>) => {
+          const filtered = incomingSubscriptions.reduce((acc, subscription) => {
+            const { id, plan: { id: planId } } = subscription
+            const successor = incomingSubscriptions.find(
+              ({ previousSubscription }) => id === previousSubscription,
+            )
+
+            acc[planId] = successor ?? subscription
+            return acc
+          }, {})
+
+          setSubscriptions(Object.values(filtered))
+        })
         .catch((error) => reportError(new UIError({
           id: 'service-fetch',
           text: 'Error while fetching subscriptions.',


### PR DESCRIPTION
Resolves https://rsklabs.atlassian.net/browse/RMKT-793

by adding a filter to the incoming subscriptions.

## Notes:
- As mentioned in the code, this is not ideal, as we make the browser work on something that could be done by the cache database (upon a query from the UI).
> This should really be done in SQL (cache) but sequelize doesn't support subquery and raw query would be impractical in this case (src: https://github.com/sequelize/sequelize/issues/5354)

## Screens:
**Before:**
![Screenshot 2021-07-14 at 09 35 02](https://user-images.githubusercontent.com/36888576/125593149-8b871c1c-bdb1-4eb1-b197-2d26f08d275d.png)
**After, when got expired only:**
![Screenshot 2021-07-14 at 09 43 58](https://user-images.githubusercontent.com/36888576/125593142-f6d6e978-7394-4097-9c0e-fe3562fb4e1a.png)
**After when got expired and renewed:**
![Screenshot 2021-07-14 at 09 37 49](https://user-images.githubusercontent.com/36888576/125593147-7950e979-7927-49c4-a338-cf1d11276287.png)
