### PR TITLE
feat(notifier-buy): shows only available plans for selection

### DIFF
--- a/src/api/rif-notifier-service/subscriptionPlans.ts
+++ b/src/api/rif-notifier-service/subscriptionPlans.ts
@@ -3,7 +3,7 @@ import { NOTIFIER_RESPONSE_STATUSES } from 'api/rif-notifier-service/models/resp
 import { logNotImplemented } from 'utils/utils'
 import { NotifierAPIService } from './interfaces'
 
-export const address = 'getSubscriptionPlans' as const
+export const address = 'getSubscriptionPlans?activePlansOnly=true' as const
 export type Address = typeof address
 
 export default class SubscriptionPlans
@@ -14,17 +14,15 @@ export default class SubscriptionPlans
 
   getActivePlans = async (): Promise<Array<SubscriptionPlanDTO>> => {
     const { status, content }: SubscriptionPlanResponse = await this.fetch()
-    const isValidResponse = status === NOTIFIER_RESPONSE_STATUSES.OK
 
-    if (!isValidResponse) {
-      this.errorReporter({
-        id: 'service-fetch',
-        text: 'Wrong response from notifier provider',
-        error: new Error(`Wrong response from notifier provider ${JSON.stringify(content)}`),
-      })
-    }
+    if (status === NOTIFIER_RESPONSE_STATUSES.OK) return content
 
-    return content.filter(({ planStatus }) => planStatus === 'ACTIVE')
+    this.errorReporter({
+      id: 'service-fetch',
+      text: 'Wrong response from notifier provider',
+      error: new Error(`Wrong response from notifier provider ${JSON.stringify(content)}`),
+    })
+    return []
   }
 
   _create = (): Promise<any> => Promise.resolve(logNotImplemented('Subscription Plans')())

--- a/src/api/rif-notifier-service/subscriptionPlans.ts
+++ b/src/api/rif-notifier-service/subscriptionPlans.ts
@@ -1,4 +1,4 @@
-import { SubscriptionPlanResponse } from 'api/rif-notifier-service/models/subscriptionPlan'
+import { SubscriptionPlanDTO, SubscriptionPlanResponse } from 'api/rif-notifier-service/models/subscriptionPlan'
 import { NOTIFIER_RESPONSE_STATUSES } from 'api/rif-notifier-service/models/response'
 import { logNotImplemented } from 'utils/utils'
 import { NotifierAPIService } from './interfaces'
@@ -12,13 +12,19 @@ export default class SubscriptionPlans
 
   _fetch = (): Promise<SubscriptionPlanResponse> => this.service.find()
 
-  hasActivePlans = async (): Promise<boolean> => {
+  getActivePlans = async (): Promise<Array<SubscriptionPlanDTO>> => {
     const { status, content }: SubscriptionPlanResponse = await this.fetch()
     const isValidResponse = status === NOTIFIER_RESPONSE_STATUSES.OK
 
-    const anyActive = content.some(({ planStatus }) => planStatus === 'ACTIVE')
+    if (!isValidResponse) {
+      this.errorReporter({
+        id: 'service-fetch',
+        text: 'Wrong response from notifier provider',
+        error: new Error(`Wrong response from notifier provider ${JSON.stringify(content)}`),
+      })
+    }
 
-    return isValidResponse && anyActive
+    return content.filter(({ planStatus }) => planStatus === 'ACTIVE')
   }
 
   _create = (): Promise<any> => Promise.resolve(logNotImplemented('Subscription Plans')())

--- a/src/components/organisms/notifier/provider/ProviderRegistrarForm.tsx
+++ b/src/components/organisms/notifier/provider/ProviderRegistrarForm.tsx
@@ -40,13 +40,13 @@ const ProviderRegistrarForm: FC<ProviderRegistrarFormProps> = ({
     },
   } = useContext<AppContextProps>(AppContext)
 
-  const validateProviderURL = async (url: string): Promise<boolean|string> => {
+  const validateProviderURL = async (url: string): Promise<boolean | string> => {
     const notifierService: SubscriptionPlans = new SubscriptionPlans(url)
     notifierService.connect(reportError)
     providersApi.connect(reportError)
     const providerService: ProvidersService = providersApi as ProvidersService
     const urlIsRegistered: boolean = await providerService.isRegisteredURL(url.replace(trailingSlashRegex, ''))
-    const hasActivePlans: boolean|undefined = await notifierService.hasActivePlans()
+    const hasActivePlans = Boolean((await notifierService.getActivePlans()).length)
     const urlMessage = urlIsRegistered ? URL_ALREADY_REGISTERED : ''
     const planMessage = hasActivePlans ? '' : NO_AVAILABLE_SUBSCRIPTION_PLAN
 
@@ -90,7 +90,7 @@ const ProviderRegistrarForm: FC<ProviderRegistrarFormProps> = ({
                 {
                   errors.endpointUrl && (
                     <Typography color="error" variant="caption">
-                      { errors.endpointUrl.message || 'Endpoint url is required'}
+                      {errors.endpointUrl.message || 'Endpoint url is required'}
                     </Typography>
                   )
                 }

--- a/src/components/pages/notifier/buy/NotifierOffersPage.tsx
+++ b/src/components/pages/notifier/buy/NotifierOffersPage.tsx
@@ -105,7 +105,8 @@ const NotifierOffersPage: FC = () => {
 
           const notifierService = new SubscriptionPlans(url)
           notifierService.connect(Logger.getInstance().debug)
-          const hasActivePlans = await notifierService.hasActivePlans()
+          // TODO: keep the result of active plans to check against the plans we got from cache and disable their selection if no active
+          const hasActivePlans = Boolean((await notifierService.getActivePlans()).length)
 
           const { priceFiatRange, ...offerDetails } = mapPlansToOffers(
             providerPlans, crypto,

--- a/src/components/pages/notifier/buy/NotifierOffersPage.tsx
+++ b/src/components/pages/notifier/buy/NotifierOffersPage.tsx
@@ -105,18 +105,24 @@ const NotifierOffersPage: FC = () => {
 
           const notifierService = new SubscriptionPlans(url)
           notifierService.connect(Logger.getInstance().debug)
-          // TODO: keep the result of active plans to check against the plans we got from cache and disable their selection if no active
-          const hasActivePlans = Boolean((await notifierService.getActivePlans()).length)
+          const notifierActivePlans = await notifierService.getActivePlans()
+          // filters the plans we got with the plans that are active in the provider
+          const availablePlans = providerPlans.filter(
+            ({ id }) => notifierActivePlans.some(
+              ({ id: notifierPlanId }) => notifierPlanId === Number(id),
+            ),
+          )
+          const hasAvailablePlans = availablePlans.length > 0
 
           const { priceFiatRange, ...offerDetails } = mapPlansToOffers(
-            providerPlans, crypto,
+            availablePlans, crypto,
           )
 
           const isSelected = selectedProvider?.id === provider
 
           const selectButton = (
             <SelectRowButton
-              disabled={!hasActivePlans}
+              disabled={!hasAvailablePlans}
               id={provider}
               isSelected={isSelected}
               handleSelect={(): void => {
@@ -126,7 +132,7 @@ const NotifierOffersPage: FC = () => {
               }}
             />
           )
-          const action1 = hasActivePlans
+          const action1 = hasAvailablePlans
             ? selectButton
             : (
               <Tooltip title="This provider doesn't have any active plan at the moment">


### PR DESCRIPTION
## Description
Compares the available plans in cache with the active plans in the notifier provider instance to check if the plan is available for new subscriptions.

Resolves [RMKT-828](https://rsklabs.atlassian.net/jira/software/projects/RMKT/boards/60?selectedIssue=RMKT-828)