### PR TITLE
fix(backport): removes on pr open

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,7 +5,6 @@ on:
       - hotfix/*
   pull_request:
     types:
-      - opened
       - closed
 
 jobs:


### PR DESCRIPTION
To stop triggering the action when it's not a hotfix.
Will still trigger on close, but won't process unless its hotfix